### PR TITLE
feat: multi-user graph sync with diff/patch model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "serde_urlencoded",
  "tiny_http",
  "toml",
+ "uuid",
 ]
 
 [[package]]
@@ -329,6 +330,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -546,6 +559,12 @@ checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r2d2"
@@ -828,10 +847,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1050,3 +1089,9 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,9 @@ serde_urlencoded = "0.7"
 # Date/time
 chrono = "0.4"
 
+# UUID generation for change_id
+uuid = { version = "1.0", features = ["v4"] }
+
 # SQLite ORM with migrations
 diesel = { version = "2.2", features = ["sqlite", "r2d2", "64-column-tables"] }
 libsqlite3-sys = { version = "0.30", features = ["bundled"] }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -185,6 +185,37 @@
 - [ ] Add `deciduous log` command to view git.log contents
 - [ ] Document git.log purpose and location in tooling files
 
+### Multi-User Namespaces & Graph Merging
+- [ ] Support multiple users/agents writing to their own namespaces
+  - Each user/agent gets isolated namespace for their decision nodes
+  - Avoid write conflicts when multiple sessions work in parallel
+  - Namespace could be: user ID, session ID, agent name, or custom tag
+- [ ] Namespace-scoped operations
+  - `deciduous add goal "..." --namespace alice`
+  - `deciduous nodes --namespace bob`
+  - Nodes tagged with namespace in metadata_json
+- [ ] Merge namespaces into unified graph
+  - `deciduous merge --from alice --into main`
+  - Conflict resolution strategies (timestamp, manual, auto-link)
+  - Preserve provenance: track which namespace each node originated from
+- [ ] Cross-namespace linking
+  - Allow edges between nodes in different namespaces
+  - "Alice's outcome depends on Bob's action"
+  - Visualize cross-namespace dependencies
+- [ ] Web UI namespace support
+  - Filter by namespace (like branch filter)
+  - Color-code nodes by namespace/author
+  - Merged view showing all namespaces together
+- [ ] Use cases:
+  - **Team collaboration**: Multiple devs working on same codebase
+  - **Multi-agent workflows**: Different AI agents with their own decision streams
+  - **PR-based isolation**: Each PR gets its own namespace, merged on PR merge
+  - **Review workflows**: Reviewer adds nodes in their namespace, author sees feedback
+- [ ] Sync/rebase semantics
+  - Similar to git branches but for decision graphs
+  - `deciduous rebase --namespace feature --onto main`
+  - Handle node ID conflicts during merge
+
 ### DuckDB for OLAP Analytics
 - [ ] Add DuckDB as optional analytical backend for decision graph queries
   - SQLite is great for OLTP (single-project, real-time logging)

--- a/docs/MULTI_USER_SYNC.md
+++ b/docs/MULTI_USER_SYNC.md
@@ -1,0 +1,158 @@
+# Multi-User Graph Sync Design
+
+## Problem Statement
+
+Multiple users work on the same codebase, each with their own local `.deciduous/deciduous.db` (gitignored). They need to:
+
+1. Export their new decisions as "diffs" or "patches"
+2. Commit these patches to the shared repository
+3. Apply patches from other users to their local database
+4. Handle references to existing nodes (edges pointing to nodes from previous sessions)
+5. Avoid ID conflicts when multiple users create nodes concurrently
+
+## Design: jj-Inspired Dual-ID Model
+
+Inspired by [Jujutsu's](https://github.com/jj-vcs/jj) separation of "change IDs" (stable) vs "commit IDs" (content-addressable):
+
+### Core Concept
+
+Each node has two identifiers:
+- **`id`** (integer): Local database primary key, auto-incremented, different per machine
+- **`change_id`** (UUID): Globally unique, stable, same across all databases
+
+### Edges Reference `change_id`
+
+When syncing, edges use `change_id` to reference nodes, not integer `id`. This allows:
+- Node 5 on Alice's machine to reference Node 3 from the shared graph
+- The same logical reference works on Bob's machine where those nodes might have different local IDs
+
+## Diff/Patch Format
+
+```json
+{
+  "version": "1.0",
+  "author": "alice",
+  "branch": "feature/auth",
+  "created_at": "2025-12-10T12:00:00Z",
+  "base_commit": "abc123",
+  "nodes": [
+    {
+      "change_id": "550e8400-e29b-41d4-a716-446655440000",
+      "node_type": "goal",
+      "title": "Implement user authentication",
+      "description": "...",
+      "status": "active",
+      "metadata_json": "{\"confidence\": 85, \"branch\": \"feature/auth\"}"
+    }
+  ],
+  "edges": [
+    {
+      "from_change_id": "550e8400-e29b-41d4-a716-446655440000",
+      "to_change_id": "existing-node-change-id",
+      "edge_type": "leads_to",
+      "rationale": "New goal builds on existing decision"
+    }
+  ]
+}
+```
+
+## Workflow
+
+### Export a Diff
+
+```bash
+# Export all nodes created since last sync
+deciduous diff export --since-commit abc123 -o patches/alice-auth.json
+
+# Export specific nodes
+deciduous diff export --nodes 172-180 -o patches/alice-auth.json
+
+# Export nodes from current branch only
+deciduous diff export --branch feature/auth -o patches/alice-auth.json
+```
+
+### Apply a Diff
+
+```bash
+# Apply a patch file to local database
+deciduous diff apply patches/bob-refactor.json
+
+# Dry-run to see what would change
+deciduous diff apply --dry-run patches/bob-refactor.json
+
+# Apply all patches in directory
+deciduous diff apply patches/*.json
+```
+
+### PR Workflow
+
+1. Alice works on `feature/auth`, creates nodes 172-180
+2. Alice exports: `deciduous diff export --branch feature/auth -o .deciduous/patches/alice-auth.json`
+3. Alice commits the patch file (not the database)
+4. Alice opens PR with the patch file
+5. PR is reviewed, merged to main
+6. Bob pulls main, runs: `deciduous diff apply .deciduous/patches/alice-auth.json`
+7. Bob's local database now has Alice's nodes (with potentially different local IDs but same change_ids)
+
+## Schema Migration
+
+Add `change_id` column to `decision_nodes` and reference columns to `decision_edges`:
+
+```sql
+-- Migration: Add change_id to nodes
+ALTER TABLE decision_nodes ADD COLUMN change_id TEXT;
+UPDATE decision_nodes SET change_id = lower(hex(randomblob(16))) WHERE change_id IS NULL;
+CREATE UNIQUE INDEX idx_nodes_change_id ON decision_nodes(change_id);
+
+-- Migration: Add change_id references to edges
+ALTER TABLE decision_edges ADD COLUMN from_change_id TEXT;
+ALTER TABLE decision_edges ADD COLUMN to_change_id TEXT;
+-- Backfill from existing integer references
+UPDATE decision_edges SET
+  from_change_id = (SELECT change_id FROM decision_nodes WHERE id = decision_edges.from_node_id),
+  to_change_id = (SELECT change_id FROM decision_nodes WHERE id = decision_edges.to_node_id);
+```
+
+## Conflict Resolution
+
+### Node Conflicts
+- Nodes are identified by `change_id` - if the same `change_id` exists, skip (idempotent)
+- Different nodes (different `change_id`) never conflict even if they have same title
+
+### Edge Conflicts
+- Edges are identified by (from_change_id, to_change_id, edge_type) tuple
+- Duplicate edges are skipped (idempotent)
+
+### Merge Strategy
+Patches are additive by default. No deletion through patches (yet).
+
+## Future Enhancements
+
+1. **Tombstones**: Mark deleted nodes/edges in patches
+2. **Branch Subscriptions**: Auto-apply patches from watched branches
+3. **Conflict Detection**: Warn when edges reference non-existent change_ids
+4. **Compression**: Binary patch format for large graphs
+5. **Signed Patches**: Cryptographic signatures for audit trail
+
+## Implementation Phases
+
+### Phase 1: Schema Migration (This PR)
+- Add `change_id` column to nodes
+- Add `from_change_id`/`to_change_id` to edges
+- Migrate existing data to have change_ids
+- Update node creation to generate UUIDs
+
+### Phase 2: Export Command
+- `deciduous diff export` command
+- JSON patch file format
+- Filter by commit, branch, or node range
+
+### Phase 3: Apply Command
+- `deciduous diff apply` command
+- Idempotent application
+- Dry-run mode
+
+### Phase 4: PR Integration
+- `.deciduous/patches/` directory convention
+- Auto-detection of unapplied patches
+- `deciduous diff status` command

--- a/docs/graph-data.json
+++ b/docs/graph-data.json
@@ -1709,6 +1709,186 @@
       "created_at": "2025-12-10T17:01:34.221203-05:00",
       "updated_at": "2025-12-10T17:01:34.221203-05:00",
       "metadata_json": "{\"branch\":\"main\",\"confidence\":95}"
+    },
+    {
+      "id": 172,
+      "node_type": "goal",
+      "title": "Design multi-user graph sync with diff/patch model for PR workflow",
+      "description": null,
+      "status": "pending",
+      "created_at": "2025-12-10T17:47:59.603521-05:00",
+      "updated_at": "2025-12-10T17:47:59.603521-05:00",
+      "metadata_json": "{\"branch\":\"feature/multi-user-graph-sync\",\"confidence\":85,\"prompt\":\"User wants multiple users writing to local copies, pushing diffs to central repo, handling references to existing nodes, integrating with PR process\"}"
+    },
+    {
+      "id": 173,
+      "node_type": "decision",
+      "title": "How to handle multi-user graph sync",
+      "description": null,
+      "status": "pending",
+      "created_at": "2025-12-10T17:48:11.012439-05:00",
+      "updated_at": "2025-12-10T17:48:11.012439-05:00",
+      "metadata_json": "{\"branch\":\"feature/multi-user-graph-sync\",\"confidence\":75,\"prompt\":\"Core problem: multiple users have local .deciduous/deciduous.db, need to sync changes to shared repo without conflicts\"}"
+    },
+    {
+      "id": 174,
+      "node_type": "option",
+      "title": "Option A: JSON diff files - export new nodes/edges as JSON patches",
+      "description": null,
+      "status": "pending",
+      "created_at": "2025-12-10T17:48:25.942729-05:00",
+      "updated_at": "2025-12-10T17:48:25.942729-05:00",
+      "metadata_json": "{\"branch\":\"feature/multi-user-graph-sync\",\"confidence\":70}"
+    },
+    {
+      "id": 175,
+      "node_type": "option",
+      "title": "Option B: Git-like content-addressable storage - hash nodes by content",
+      "description": null,
+      "status": "pending",
+      "created_at": "2025-12-10T17:48:31.188458-05:00",
+      "updated_at": "2025-12-10T17:48:31.188458-05:00",
+      "metadata_json": "{\"branch\":\"feature/multi-user-graph-sync\",\"confidence\":60}"
+    },
+    {
+      "id": 176,
+      "node_type": "option",
+      "title": "Option C: UUID-based node IDs - globally unique, no conflicts",
+      "description": null,
+      "status": "pending",
+      "created_at": "2025-12-10T17:48:36.189513-05:00",
+      "updated_at": "2025-12-10T17:48:36.189513-05:00",
+      "metadata_json": "{\"branch\":\"feature/multi-user-graph-sync\",\"confidence\":75}"
+    },
+    {
+      "id": 177,
+      "node_type": "option",
+      "title": "Option D: Hybrid - UUIDs for new nodes, stable refs for existing nodes",
+      "description": null,
+      "status": "pending",
+      "created_at": "2025-12-10T17:48:42.822383-05:00",
+      "updated_at": "2025-12-10T17:48:42.822383-05:00",
+      "metadata_json": "{\"branch\":\"feature/multi-user-graph-sync\",\"confidence\":80}"
+    },
+    {
+      "id": 178,
+      "node_type": "observation",
+      "title": "jj (Jujutsu) uses change IDs vs commit IDs - change IDs are stable across rebases",
+      "description": null,
+      "status": "pending",
+      "created_at": "2025-12-10T17:48:58.106355-05:00",
+      "updated_at": "2025-12-10T17:48:58.106355-05:00",
+      "metadata_json": "{\"branch\":\"feature/multi-user-graph-sync\",\"confidence\":85}"
+    },
+    {
+      "id": 179,
+      "node_type": "observation",
+      "title": "jj key insight: change IDs are stable across rebases, separate from commit IDs. Uses bit-reversed commit ID for git-imported commits",
+      "description": null,
+      "status": "pending",
+      "created_at": "2025-12-10T17:49:32.528532-05:00",
+      "updated_at": "2025-12-10T17:49:32.528532-05:00",
+      "metadata_json": "{\"branch\":\"feature/multi-user-graph-sync\",\"confidence\":90}"
+    },
+    {
+      "id": 180,
+      "node_type": "option",
+      "title": "Option E: jj-inspired - UUID 'change_id' per node, separate from integer 'id', stable across sync",
+      "description": null,
+      "status": "pending",
+      "created_at": "2025-12-10T17:49:56.483634-05:00",
+      "updated_at": "2025-12-10T17:49:56.483634-05:00",
+      "metadata_json": "{\"branch\":\"feature/multi-user-graph-sync\",\"confidence\":85}"
+    },
+    {
+      "id": 181,
+      "node_type": "action",
+      "title": "Choosing Option E: jj-inspired dual-ID model",
+      "description": null,
+      "status": "pending",
+      "created_at": "2025-12-10T17:50:09.138830-05:00",
+      "updated_at": "2025-12-10T17:50:09.138830-05:00",
+      "metadata_json": "{\"branch\":\"feature/multi-user-graph-sync\",\"confidence\":85,\"prompt\":\"change_id (UUID) is globally unique and stable, id (int) is local to each database. Diffs use change_ids for references.\"}"
+    },
+    {
+      "id": 182,
+      "node_type": "observation",
+      "title": "Current schema uses auto-increment integer ids - not suitable for multi-user. Need to add change_id UUID column",
+      "description": null,
+      "status": "pending",
+      "created_at": "2025-12-10T17:50:46.768696-05:00",
+      "updated_at": "2025-12-10T17:50:46.768696-05:00",
+      "metadata_json": "{\"branch\":\"feature/multi-user-graph-sync\",\"confidence\":90}"
+    },
+    {
+      "id": 183,
+      "node_type": "action",
+      "title": "Design document created: MULTI_USER_SYNC.md",
+      "description": null,
+      "status": "pending",
+      "created_at": "2025-12-10T17:51:32.528339-05:00",
+      "updated_at": "2025-12-10T17:51:32.528339-05:00",
+      "metadata_json": "{\"branch\":\"feature/multi-user-graph-sync\",\"confidence\":90,\"files\":[\"docs/MULTI_USER_SYNC.md\"]}"
+    },
+    {
+      "id": 184,
+      "node_type": "decision",
+      "title": "Diff/Patch JSON format specification",
+      "description": null,
+      "status": "pending",
+      "created_at": "2025-12-10T17:51:42.728283-05:00",
+      "updated_at": "2025-12-10T17:51:42.728283-05:00",
+      "metadata_json": "{\"branch\":\"feature/multi-user-graph-sync\",\"confidence\":85,\"prompt\":\"Define version, author, branch, base_commit, nodes array, edges array structure\"}"
+    },
+    {
+      "id": 185,
+      "node_type": "decision",
+      "title": "PR-based workflow for syncing patches",
+      "description": null,
+      "status": "pending",
+      "created_at": "2025-12-10T17:51:47.932980-05:00",
+      "updated_at": "2025-12-10T17:51:47.932980-05:00",
+      "metadata_json": "{\"branch\":\"feature/multi-user-graph-sync\",\"confidence\":85,\"prompt\":\"Export to .deciduous/patches/, commit files, PR merges them, others apply after pull\"}"
+    },
+    {
+      "id": 186,
+      "node_type": "decision",
+      "title": "Conflict resolution strategy: idempotent, additive patches",
+      "description": null,
+      "status": "pending",
+      "created_at": "2025-12-10T17:51:57.237027-05:00",
+      "updated_at": "2025-12-10T17:51:57.237027-05:00",
+      "metadata_json": "{\"branch\":\"feature/multi-user-graph-sync\",\"confidence\":80,\"prompt\":\"Same change_id = skip, edges dedupe by tuple, no deletions in v1\"}"
+    },
+    {
+      "id": 187,
+      "node_type": "decision",
+      "title": "Schema migration: add change_id UUID to nodes, from/to_change_id to edges",
+      "description": null,
+      "status": "pending",
+      "created_at": "2025-12-10T17:52:03.944998-05:00",
+      "updated_at": "2025-12-10T17:52:03.944998-05:00",
+      "metadata_json": "{\"branch\":\"feature/multi-user-graph-sync\",\"confidence\":90,\"prompt\":\"Backfill existing with random UUIDs, create unique index\"}"
+    },
+    {
+      "id": 188,
+      "node_type": "action",
+      "title": "Implemented change_id schema migration, diff export/apply commands",
+      "description": null,
+      "status": "pending",
+      "created_at": "2025-12-10T18:00:07.905966-05:00",
+      "updated_at": "2025-12-10T18:00:07.905966-05:00",
+      "metadata_json": "{\"branch\":\"feature/multi-user-graph-sync\",\"confidence\":90,\"files\":[\"src/schema.rs\",\"src/db.rs\",\"src/diff.rs\",\"src/main.rs\"]}"
+    },
+    {
+      "id": 189,
+      "node_type": "outcome",
+      "title": "Multi-user diff/patch system working - export, apply, migrate commands all functional",
+      "description": null,
+      "status": "pending",
+      "created_at": "2025-12-10T18:02:32.017798-05:00",
+      "updated_at": "2025-12-10T18:02:32.017798-05:00",
+      "metadata_json": "{\"branch\":\"feature/multi-user-graph-sync\",\"confidence\":95}"
     }
   ],
   "edges": [
@@ -2719,6 +2899,168 @@
       "weight": 1.0,
       "rationale": "Fixed the bug - viewer.html was outdated",
       "created_at": "2025-12-10T17:01:39.654468-05:00"
+    },
+    {
+      "id": 113,
+      "from_node_id": 172,
+      "to_node_id": 173,
+      "edge_type": "leads_to",
+      "weight": 1.0,
+      "rationale": "Goal spawns this core design decision",
+      "created_at": "2025-12-10T17:48:17.790191-05:00"
+    },
+    {
+      "id": 114,
+      "from_node_id": 173,
+      "to_node_id": 174,
+      "edge_type": "leads_to",
+      "weight": 1.0,
+      "rationale": "Option A considered",
+      "created_at": "2025-12-10T17:48:48.812104-05:00"
+    },
+    {
+      "id": 115,
+      "from_node_id": 173,
+      "to_node_id": 175,
+      "edge_type": "leads_to",
+      "weight": 1.0,
+      "rationale": "Option B considered",
+      "created_at": "2025-12-10T17:48:48.820317-05:00"
+    },
+    {
+      "id": 116,
+      "from_node_id": 173,
+      "to_node_id": 176,
+      "edge_type": "leads_to",
+      "weight": 1.0,
+      "rationale": "Option C considered",
+      "created_at": "2025-12-10T17:48:48.828429-05:00"
+    },
+    {
+      "id": 117,
+      "from_node_id": 173,
+      "to_node_id": 177,
+      "edge_type": "leads_to",
+      "weight": 1.0,
+      "rationale": "Option D considered",
+      "created_at": "2025-12-10T17:48:48.839756-05:00"
+    },
+    {
+      "id": 118,
+      "from_node_id": 173,
+      "to_node_id": 180,
+      "edge_type": "leads_to",
+      "weight": 1.0,
+      "rationale": "Option E considered - jj-inspired approach",
+      "created_at": "2025-12-10T17:50:02.562877-05:00"
+    },
+    {
+      "id": 119,
+      "from_node_id": 178,
+      "to_node_id": 180,
+      "edge_type": "leads_to",
+      "weight": 1.0,
+      "rationale": "jj observation informs this option",
+      "created_at": "2025-12-10T17:50:02.570775-05:00"
+    },
+    {
+      "id": 120,
+      "from_node_id": 173,
+      "to_node_id": 181,
+      "edge_type": "chosen",
+      "weight": 1.0,
+      "rationale": "Decision resolved with Option E",
+      "created_at": "2025-12-10T17:50:14.719399-05:00"
+    },
+    {
+      "id": 121,
+      "from_node_id": 180,
+      "to_node_id": 181,
+      "edge_type": "leads_to",
+      "weight": 1.0,
+      "rationale": "Option E selected",
+      "created_at": "2025-12-10T17:50:14.728370-05:00"
+    },
+    {
+      "id": 122,
+      "from_node_id": 181,
+      "to_node_id": 182,
+      "edge_type": "leads_to",
+      "weight": 1.0,
+      "rationale": "Action leads to this observation about schema",
+      "created_at": "2025-12-10T17:50:52.394863-05:00"
+    },
+    {
+      "id": 123,
+      "from_node_id": 181,
+      "to_node_id": 183,
+      "edge_type": "leads_to",
+      "weight": 1.0,
+      "rationale": "Action follows from design decision",
+      "created_at": "2025-12-10T17:51:36.999074-05:00"
+    },
+    {
+      "id": 124,
+      "from_node_id": 183,
+      "to_node_id": 184,
+      "edge_type": "leads_to",
+      "weight": 1.0,
+      "rationale": "Design doc specifies format",
+      "created_at": "2025-12-10T17:52:10.186945-05:00"
+    },
+    {
+      "id": 125,
+      "from_node_id": 183,
+      "to_node_id": 185,
+      "edge_type": "leads_to",
+      "weight": 1.0,
+      "rationale": "Design doc specifies workflow",
+      "created_at": "2025-12-10T17:52:10.195539-05:00"
+    },
+    {
+      "id": 126,
+      "from_node_id": 183,
+      "to_node_id": 186,
+      "edge_type": "leads_to",
+      "weight": 1.0,
+      "rationale": "Design doc specifies conflict resolution",
+      "created_at": "2025-12-10T17:52:10.204692-05:00"
+    },
+    {
+      "id": 127,
+      "from_node_id": 183,
+      "to_node_id": 187,
+      "edge_type": "leads_to",
+      "weight": 1.0,
+      "rationale": "Design doc specifies schema migration",
+      "created_at": "2025-12-10T17:52:10.211835-05:00"
+    },
+    {
+      "id": 128,
+      "from_node_id": 187,
+      "to_node_id": 188,
+      "edge_type": "leads_to",
+      "weight": 1.0,
+      "rationale": "Schema migration decision led to implementation",
+      "created_at": "2025-12-10T18:00:12.909407-05:00"
+    },
+    {
+      "id": 129,
+      "from_node_id": 172,
+      "to_node_id": 189,
+      "edge_type": "leads_to",
+      "weight": 1.0,
+      "rationale": "Goal achieved - multi-user sync system working",
+      "created_at": "2025-12-10T18:02:38.512831-05:00"
+    },
+    {
+      "id": 130,
+      "from_node_id": 188,
+      "to_node_id": 189,
+      "edge_type": "leads_to",
+      "weight": 1.0,
+      "rationale": "Implementation led to successful outcome",
+      "created_at": "2025-12-10T18:02:38.523352-05:00"
     }
   ]
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,317 @@
+//! Diff/patch functionality for multi-user graph sync
+//!
+//! Implements jj-inspired change_id based syncing between local databases
+//! and version-controlled patch files.
+
+use crate::db::{Database, DecisionNode, DecisionEdge};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::Path;
+
+/// A patch file containing nodes and edges to sync
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphPatch {
+    /// Patch format version
+    pub version: String,
+    /// Author who created this patch
+    pub author: Option<String>,
+    /// Git branch this patch was created from
+    pub branch: Option<String>,
+    /// Timestamp when patch was created
+    pub created_at: String,
+    /// Git commit hash at time of patch creation
+    pub base_commit: Option<String>,
+    /// Nodes included in this patch
+    pub nodes: Vec<PatchNode>,
+    /// Edges included in this patch
+    pub edges: Vec<PatchEdge>,
+}
+
+/// A node in a patch file (uses change_id, not integer id)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatchNode {
+    /// Globally unique change ID
+    pub change_id: String,
+    /// Node type: goal, decision, option, action, outcome, observation
+    pub node_type: String,
+    /// Node title
+    pub title: String,
+    /// Optional description
+    pub description: Option<String>,
+    /// Node status
+    pub status: String,
+    /// Metadata JSON (confidence, branch, prompt, files, etc.)
+    pub metadata_json: Option<String>,
+    /// Created timestamp
+    pub created_at: String,
+}
+
+/// An edge in a patch file (uses change_ids for references)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatchEdge {
+    /// Source node change_id
+    pub from_change_id: String,
+    /// Target node change_id
+    pub to_change_id: String,
+    /// Edge type: leads_to, chosen, etc.
+    pub edge_type: String,
+    /// Optional rationale for the edge
+    pub rationale: Option<String>,
+}
+
+impl GraphPatch {
+    /// Create a new empty patch
+    pub fn new(author: Option<String>, branch: Option<String>, base_commit: Option<String>) -> Self {
+        Self {
+            version: "1.0".to_string(),
+            author,
+            branch,
+            created_at: chrono::Local::now().to_rfc3339(),
+            base_commit,
+            nodes: Vec::new(),
+            edges: Vec::new(),
+        }
+    }
+
+    /// Load a patch from a JSON file
+    pub fn load(path: &Path) -> Result<Self, String> {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| format!("Failed to read patch file: {}", e))?;
+        serde_json::from_str(&content)
+            .map_err(|e| format!("Failed to parse patch JSON: {}", e))
+    }
+
+    /// Save the patch to a JSON file
+    pub fn save(&self, path: &Path) -> Result<(), String> {
+        let content = serde_json::to_string_pretty(self)
+            .map_err(|e| format!("Failed to serialize patch: {}", e))?;
+
+        // Create parent directories if needed
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create directory: {}", e))?;
+        }
+
+        std::fs::write(path, content)
+            .map_err(|e| format!("Failed to write patch file: {}", e))
+    }
+
+    /// Add a node to the patch
+    pub fn add_node(&mut self, node: &DecisionNode) {
+        self.nodes.push(PatchNode {
+            change_id: node.change_id.clone(),
+            node_type: node.node_type.clone(),
+            title: node.title.clone(),
+            description: node.description.clone(),
+            status: node.status.clone(),
+            metadata_json: node.metadata_json.clone(),
+            created_at: node.created_at.clone(),
+        });
+    }
+
+    /// Add an edge to the patch
+    pub fn add_edge(&mut self, edge: &DecisionEdge) {
+        if let (Some(from_cid), Some(to_cid)) = (&edge.from_change_id, &edge.to_change_id) {
+            self.edges.push(PatchEdge {
+                from_change_id: from_cid.clone(),
+                to_change_id: to_cid.clone(),
+                edge_type: edge.edge_type.clone(),
+                rationale: edge.rationale.clone(),
+            });
+        }
+    }
+}
+
+/// Result of applying a patch
+#[derive(Debug, Default)]
+pub struct ApplyResult {
+    /// Number of nodes added
+    pub nodes_added: usize,
+    /// Number of nodes skipped (already existed)
+    pub nodes_skipped: usize,
+    /// Number of edges added
+    pub edges_added: usize,
+    /// Number of edges skipped (already existed)
+    pub edges_skipped: usize,
+    /// Edges that couldn't be created (missing nodes)
+    pub edges_failed: Vec<String>,
+}
+
+impl Database {
+    /// Export nodes and edges as a patch
+    pub fn export_patch(
+        &self,
+        node_ids: Option<Vec<i32>>,
+        branch_filter: Option<&str>,
+        author: Option<String>,
+        base_commit: Option<String>,
+    ) -> Result<GraphPatch, crate::db::DbError> {
+        let all_nodes = self.get_all_nodes()?;
+        let all_edges = self.get_all_edges()?;
+
+        // Get current branch for patch metadata
+        let current_branch = crate::db::get_current_git_branch();
+        let mut patch = GraphPatch::new(author, current_branch, base_commit);
+
+        // Filter nodes
+        let nodes: Vec<&DecisionNode> = all_nodes.iter().filter(|n| {
+            // Filter by node IDs if specified
+            if let Some(ref ids) = node_ids {
+                if !ids.contains(&n.id) {
+                    return false;
+                }
+            }
+
+            // Filter by branch if specified
+            if let Some(branch) = branch_filter {
+                if let Some(ref meta) = n.metadata_json {
+                    if let Ok(json) = serde_json::from_str::<serde_json::Value>(meta) {
+                        if let Some(node_branch) = json.get("branch").and_then(|b| b.as_str()) {
+                            return node_branch == branch;
+                        }
+                    }
+                }
+                return false; // No branch metadata and branch filter specified
+            }
+
+            true
+        }).collect();
+
+        // Collect change_ids of nodes being exported
+        let change_ids: HashSet<&str> = nodes.iter()
+            .map(|n| n.change_id.as_str())
+            .collect();
+
+        // Add nodes to patch
+        for node in &nodes {
+            patch.add_node(node);
+        }
+
+        // Add edges where both endpoints are in the patch
+        for edge in &all_edges {
+            if let (Some(ref from_cid), Some(ref to_cid)) = (&edge.from_change_id, &edge.to_change_id) {
+                if change_ids.contains(from_cid.as_str()) || change_ids.contains(to_cid.as_str()) {
+                    patch.add_edge(edge);
+                }
+            }
+        }
+
+        Ok(patch)
+    }
+
+    /// Apply a patch to the database
+    pub fn apply_patch(&self, patch: &GraphPatch, dry_run: bool) -> Result<ApplyResult, crate::db::DbError> {
+        let mut result = ApplyResult::default();
+
+        // Get existing change_ids
+        let existing_nodes = self.get_all_nodes()?;
+        let existing_change_ids: HashSet<String> = existing_nodes.iter()
+            .map(|n| n.change_id.clone())
+            .collect();
+
+        // Track newly added change_ids -> local ids
+        let mut change_id_to_local_id: std::collections::HashMap<String, i32> = existing_nodes.iter()
+            .map(|n| (n.change_id.clone(), n.id))
+            .collect();
+
+        // Apply nodes
+        for patch_node in &patch.nodes {
+            if existing_change_ids.contains(&patch_node.change_id) {
+                result.nodes_skipped += 1;
+                continue;
+            }
+
+            if !dry_run {
+                // Get branch from metadata
+                let branch = patch_node.metadata_json.as_ref()
+                    .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+                    .and_then(|j| j.get("branch").and_then(|b| b.as_str()).map(|s| s.to_string()));
+
+                let confidence = patch_node.metadata_json.as_ref()
+                    .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+                    .and_then(|j| j.get("confidence").and_then(|c| c.as_u64()).map(|c| c as u8));
+
+                let prompt = patch_node.metadata_json.as_ref()
+                    .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+                    .and_then(|j| j.get("prompt").and_then(|p| p.as_str()).map(|s| s.to_string()));
+
+                let files = patch_node.metadata_json.as_ref()
+                    .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+                    .and_then(|j| j.get("files").and_then(|f| {
+                        if let Some(arr) = f.as_array() {
+                            Some(arr.iter()
+                                .filter_map(|v| v.as_str())
+                                .collect::<Vec<_>>()
+                                .join(","))
+                        } else {
+                            None
+                        }
+                    }));
+
+                // Create node with explicit change_id
+                let local_id = self.create_node_with_change_id(
+                    &patch_node.change_id,
+                    &patch_node.node_type,
+                    &patch_node.title,
+                    patch_node.description.as_deref(),
+                    confidence,
+                    None, // commit
+                    prompt.as_deref(),
+                    files.as_deref(),
+                    branch.as_deref(),
+                )?;
+
+                change_id_to_local_id.insert(patch_node.change_id.clone(), local_id);
+            }
+
+            result.nodes_added += 1;
+        }
+
+        // Get existing edges (by change_id pairs)
+        let existing_edges = self.get_all_edges()?;
+        let existing_edge_keys: HashSet<(String, String, String)> = existing_edges.iter()
+            .filter_map(|e| {
+                match (&e.from_change_id, &e.to_change_id) {
+                    (Some(from), Some(to)) => Some((from.clone(), to.clone(), e.edge_type.clone())),
+                    _ => None,
+                }
+            })
+            .collect();
+
+        // Apply edges
+        for patch_edge in &patch.edges {
+            let edge_key = (
+                patch_edge.from_change_id.clone(),
+                patch_edge.to_change_id.clone(),
+                patch_edge.edge_type.clone(),
+            );
+
+            if existing_edge_keys.contains(&edge_key) {
+                result.edges_skipped += 1;
+                continue;
+            }
+
+            // Look up local IDs
+            let from_id = change_id_to_local_id.get(&patch_edge.from_change_id);
+            let to_id = change_id_to_local_id.get(&patch_edge.to_change_id);
+
+            match (from_id, to_id) {
+                (Some(&from), Some(&to)) => {
+                    if !dry_run {
+                        self.create_edge(from, to, &patch_edge.edge_type, patch_edge.rationale.as_deref())?;
+                    }
+                    result.edges_added += 1;
+                }
+                _ => {
+                    let msg = format!(
+                        "Edge {} -> {} ({}): missing node(s)",
+                        patch_edge.from_change_id, patch_edge.to_change_id, patch_edge.edge_type
+                    );
+                    result.edges_failed.push(msg);
+                }
+            }
+        }
+
+        Ok(result)
+    }
+}

--- a/src/export.rs
+++ b/src/export.rs
@@ -523,6 +523,7 @@ mod tests {
             nodes: vec![
                 DecisionNode {
                     id: 1,
+                    change_id: "change-id-1".to_string(),
                     node_type: "goal".to_string(),
                     title: "Build feature X".to_string(),
                     description: None,
@@ -533,6 +534,7 @@ mod tests {
                 },
                 DecisionNode {
                     id: 2,
+                    change_id: "change-id-2".to_string(),
                     node_type: "decision".to_string(),
                     title: "Choose approach".to_string(),
                     description: None,
@@ -543,6 +545,7 @@ mod tests {
                 },
                 DecisionNode {
                     id: 3,
+                    change_id: "change-id-3".to_string(),
                     node_type: "action".to_string(),
                     title: "Implement solution".to_string(),
                     description: None,
@@ -557,6 +560,8 @@ mod tests {
                     id: 1,
                     from_node_id: 1,
                     to_node_id: 2,
+                    from_change_id: Some("change-id-1".to_string()),
+                    to_change_id: Some("change-id-2".to_string()),
                     edge_type: "leads_to".to_string(),
                     weight: Some(1.0),
                     rationale: Some("Goal requires decision".to_string()),
@@ -566,6 +571,8 @@ mod tests {
                     id: 2,
                     from_node_id: 2,
                     to_node_id: 3,
+                    from_change_id: Some("change-id-2".to_string()),
+                    to_change_id: Some("change-id-3".to_string()),
                     edge_type: "leads_to".to_string(),
                     weight: Some(1.0),
                     rationale: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@
 
 pub mod config;
 pub mod db;
+pub mod diff;
 pub mod export;
 pub mod init;
 pub mod schema;
@@ -48,8 +49,9 @@ pub mod serve;
 pub use config::Config;
 pub use db::{
     CommandLog, Database, DbRecord, DbSummary, DecisionEdge, DecisionGraph, DecisionNode,
-    CURRENT_SCHEMA, get_current_git_branch,
+    CURRENT_SCHEMA, get_current_git_branch, build_metadata_json,
 };
+pub use diff::{GraphPatch, PatchNode, PatchEdge, ApplyResult};
 pub use export::{graph_to_dot, generate_pr_writeup, filter_graph_from_roots, filter_graph_by_ids, parse_node_range, DotConfig, WriteupConfig};
 
 #[cfg(test)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -13,6 +13,7 @@ diesel::table! {
 diesel::table! {
     decision_nodes (id) {
         id -> Integer,
+        change_id -> Text,
         node_type -> Text,
         title -> Text,
         description -> Nullable<Text>,
@@ -28,6 +29,8 @@ diesel::table! {
         id -> Integer,
         from_node_id -> Integer,
         to_node_id -> Integer,
+        from_change_id -> Nullable<Text>,
+        to_change_id -> Nullable<Text>,
         edge_type -> Text,
         weight -> Nullable<Double>,
         rationale -> Nullable<Text>,


### PR DESCRIPTION
## Summary

- **jj-inspired design** for syncing decision graphs across multiple users/machines
- Each node gets a stable UUID `change_id` that survives across different databases
- Export decisions as JSON patch files, commit to git, others apply locally
- Idempotent application - same patch can be applied multiple times safely

### New Commands

```bash
# Export nodes as a patch file
deciduous diff export --nodes 172-188 -o .deciduous/patches/feature.json --author alice

# Apply patches (idempotent)
deciduous diff apply .deciduous/patches/*.json

# Show patch status
deciduous diff status

# Manual migration (auto-runs on open)
deciduous migrate
```

### Schema Changes

- `decision_nodes.change_id` - UUID, globally unique, stable across databases
- `decision_edges.from_change_id` / `to_change_id` - stable edge references
- Auto-migration on database open for existing databases

### Workflow

1. Alice creates nodes: `deciduous add goal "Feature X" -c 90`
2. Alice exports: `deciduous diff export --branch feature-x -o patches/alice.json`
3. Alice commits and pushes the patch file
4. Bob pulls, applies: `deciduous diff apply patches/alice.json`
5. Bob's local db now has Alice's nodes (different local IDs, same change_ids)
6. If Bob re-applies the same patch, it's idempotent (0 added, all skipped)

## Test plan

- [x] Build passes: `cargo build --release`
- [x] Tests pass: `cargo test`
- [x] Auto-migration works on existing database (added change_id to 188 nodes)
- [x] Export command produces valid JSON with change_ids
- [x] Apply command creates nodes in fresh database
- [x] Idempotent: re-applying same patch skips existing nodes/edges
- [ ] Manual testing by user

## Design Doc

See `docs/MULTI_USER_SYNC.md` for full design documentation.