### PR TITLE
feat: add terminal user interface (TUI) for decision graph exploration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +81,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -84,6 +96,21 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -177,10 +204,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "futures-core",
+ "mio 1.1.1",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
 
 [[package]]
 name = "darling"
@@ -188,8 +280,22 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -208,11 +314,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
  "syn",
 ]
@@ -224,13 +341,17 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
+ "crossterm",
  "diesel",
  "libsqlite3-sys",
+ "notify",
+ "ratatui 0.29.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tiny_http",
  "toml",
+ "tui-tree-widget",
  "uuid",
 ]
 
@@ -291,7 +412,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd122633e4bef06db27737f21d3738fb89c8f6d5360d6d9d7635dda142a7757e"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "either",
  "heck",
  "proc-macro2",
@@ -312,6 +433,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +467,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +480,21 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "getrandom"
@@ -342,6 +506,17 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -399,7 +574,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+dependencies = [
+ "darling 0.20.11",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -407,6 +624,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -425,6 +651,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +683,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "libredox"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +703,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "lock_api"
@@ -463,10 +726,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "num-conv"
@@ -517,6 +832,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -578,12 +899,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+dependencies = [
+ "bitflags 2.10.0",
+ "cassowary",
+ "compact_str",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "strum_macros",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.10.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -597,6 +972,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scheduled-thread-pool"
@@ -684,6 +1068,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 1.1.1",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,10 +1119,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -835,10 +1277,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tui-tree-widget"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0b54061d997162f225bed5d2147574af0648480214759a000e33f6cea0017a"
+dependencies = [
+ "ratatui 0.28.1",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "utf8parse"
@@ -862,6 +1343,22 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -941,6 +1438,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,11 +1529,29 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1019,19 +1565,57 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1040,10 +1624,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1052,10 +1660,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1064,10 +1690,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1076,10 +1726,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,14 @@ libsqlite3-sys = { version = "0.30", features = ["bundled"] }
 # Colored terminal output
 colored = "2.0"
 
+# TUI
+ratatui = "0.29"
+crossterm = { version = "0.28", features = ["event-stream"] }
+tui-tree-widget = "0.22"
+
+# File watching for TUI auto-refresh
+notify = "6.1"
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub mod export;
 pub mod init;
 pub mod schema;
 pub mod serve;
+pub mod tui;
 
 pub use config::Config;
 pub use db::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,6 +219,13 @@ enum Command {
 
     /// Migrate database to add change_id columns (for multi-user sync)
     Migrate,
+
+    /// Launch the terminal user interface
+    Tui {
+        /// Optional database path (default: auto-discover)
+        #[arg(short, long)]
+        db: Option<PathBuf>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -293,6 +300,15 @@ fn main() {
         };
 
         if let Err(e) = deciduous::init::update_tooling(editor) {
+            eprintln!("{} {}", "Error:".red(), e);
+            std::process::exit(1);
+        }
+        return;
+    }
+
+    // Handle TUI separately - it has its own event loop
+    if let Command::Tui { db } = args.command {
+        if let Err(e) = deciduous::tui::run(db) {
             eprintln!("{} {}", "Error:".red(), e);
             std::process::exit(1);
         }
@@ -873,6 +889,8 @@ fn main() {
                 }
             }
         }
+
+        Command::Tui { .. } => unreachable!(), // Handled above
     }
 }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,0 +1,437 @@
+//! Application state for the TUI
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use crossterm::event::{MouseEvent, MouseEventKind, MouseButton};
+
+use crate::{Database, DecisionGraph, DecisionNode, DecisionEdge};
+use super::types;
+
+/// Current view mode
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum View {
+    Timeline,
+    Dag,
+}
+
+/// Current input focus
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Focus {
+    List,
+    Detail,
+    Search,
+    FilePicker,
+    Help,
+}
+
+/// Input mode
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    Normal,
+    Search,
+    Command,
+}
+
+/// File picker state for multi-select
+#[derive(Debug, Clone)]
+pub struct FilePicker {
+    pub files: Vec<String>,
+    pub selected: Vec<bool>,
+    pub cursor: usize,
+}
+
+impl FilePicker {
+    pub fn new(files: Vec<String>) -> Self {
+        let len = files.len();
+        Self {
+            files,
+            selected: vec![false; len],
+            cursor: 0,
+        }
+    }
+
+    pub fn toggle_current(&mut self) {
+        if !self.files.is_empty() {
+            self.selected[self.cursor] = !self.selected[self.cursor];
+        }
+    }
+
+    pub fn move_up(&mut self) {
+        if self.cursor > 0 {
+            self.cursor -= 1;
+        }
+    }
+
+    pub fn move_down(&mut self) {
+        if self.cursor + 1 < self.files.len() {
+            self.cursor += 1;
+        }
+    }
+
+    pub fn get_selected_files(&self) -> Vec<String> {
+        self.files
+            .iter()
+            .zip(self.selected.iter())
+            .filter(|(_, &sel)| sel)
+            .map(|(f, _)| f.clone())
+            .collect()
+    }
+}
+
+/// Main application state
+pub struct App {
+    // Database
+    db: Database,
+    db_path: PathBuf,
+
+    // Graph data
+    pub graph: DecisionGraph,
+    pub filtered_nodes: Vec<DecisionNode>,
+
+    // View state
+    pub current_view: View,
+    pub selected_index: usize,
+    pub scroll_offset: usize,
+
+    // Detail panel
+    pub detail_expanded: bool,
+    pub detail_scroll: usize,
+
+    // Filters
+    pub type_filter: Option<String>,
+    pub branch_filter: Option<String>,
+    pub search_query: String,
+
+    // UI state
+    pub focus: Focus,
+    pub mode: Mode,
+    pub file_picker: Option<FilePicker>,
+    pub show_help: bool,
+
+    // Viewport
+    pub viewport_width: u16,
+    pub viewport_height: u16,
+
+    // DAG view state
+    pub dag_offset_x: i32,
+    pub dag_offset_y: i32,
+    pub dag_zoom: f32,
+
+    // Refresh indicator
+    pub refresh_shown_at: Option<Instant>,
+
+    // Vim-style 'g' prefix tracking
+    pub pending_g: bool,
+
+    // Status message
+    pub status_message: Option<(String, Instant)>,
+}
+
+impl App {
+    pub fn new(db_path: Option<PathBuf>) -> Result<Self, Box<dyn std::error::Error>> {
+        let db = if let Some(path) = &db_path {
+            std::env::set_var("DECIDUOUS_DB_PATH", path);
+            Database::open()?
+        } else {
+            Database::open()?
+        };
+
+        let actual_path = Database::db_path();
+        let graph = db.get_graph()?;
+        let filtered_nodes = graph.nodes.clone();
+
+        // Sort by created_at descending (newest first)
+        let mut filtered_nodes = filtered_nodes;
+        filtered_nodes.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+        Ok(Self {
+            db,
+            db_path: actual_path,
+            graph,
+            filtered_nodes,
+            current_view: View::Timeline,
+            selected_index: 0,
+            scroll_offset: 0,
+            detail_expanded: true,
+            detail_scroll: 0,
+            type_filter: None,
+            branch_filter: None,
+            search_query: String::new(),
+            focus: Focus::List,
+            mode: Mode::Normal,
+            file_picker: None,
+            show_help: false,
+            viewport_width: 80,
+            viewport_height: 24,
+            dag_offset_x: 0,
+            dag_offset_y: 0,
+            dag_zoom: 1.0,
+            refresh_shown_at: None,
+            pending_g: false,
+            status_message: None,
+        })
+    }
+
+    pub fn db_path(&self) -> &Path {
+        &self.db_path
+    }
+
+    /// Reload the graph from database
+    pub fn reload_graph(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        self.graph = self.db.get_graph()?;
+        self.apply_filters();
+        Ok(())
+    }
+
+    /// Show the refresh indicator
+    pub fn show_refresh_indicator(&mut self) {
+        self.refresh_shown_at = Some(Instant::now());
+    }
+
+    /// Periodic tick for animations
+    pub fn tick(&mut self) {
+        // Clear refresh indicator after 2 seconds
+        if let Some(shown_at) = self.refresh_shown_at {
+            if shown_at.elapsed().as_secs() >= 2 {
+                self.refresh_shown_at = None;
+            }
+        }
+
+        // Clear status message after 3 seconds
+        if let Some((_, shown_at)) = &self.status_message {
+            if shown_at.elapsed().as_secs() >= 3 {
+                self.status_message = None;
+            }
+        }
+    }
+
+    /// Apply current filters to the node list
+    pub fn apply_filters(&mut self) {
+        let mut nodes: Vec<DecisionNode> = self.graph.nodes.clone();
+
+        // Type filter
+        if let Some(ref type_filter) = self.type_filter {
+            nodes.retain(|n| &n.node_type == type_filter);
+        }
+
+        // Branch filter
+        if let Some(ref branch_filter) = self.branch_filter {
+            nodes.retain(|n| {
+                types::get_branch(n)
+                    .map(|b| b == *branch_filter)
+                    .unwrap_or(false)
+            });
+        }
+
+        // Search filter
+        if !self.search_query.is_empty() {
+            let query = self.search_query.to_lowercase();
+            nodes.retain(|n| {
+                n.title.to_lowercase().contains(&query)
+                    || n.description
+                        .as_ref()
+                        .map(|d| d.to_lowercase().contains(&query))
+                        .unwrap_or(false)
+            });
+        }
+
+        // Sort by created_at descending
+        nodes.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+        self.filtered_nodes = nodes;
+
+        // Adjust selection if needed
+        if self.selected_index >= self.filtered_nodes.len() && !self.filtered_nodes.is_empty() {
+            self.selected_index = self.filtered_nodes.len() - 1;
+        }
+    }
+
+    /// Get currently selected node
+    pub fn selected_node(&self) -> Option<&DecisionNode> {
+        self.filtered_nodes.get(self.selected_index)
+    }
+
+    /// Get edges for a node
+    pub fn get_node_edges(&self, node_id: i32) -> (Vec<&DecisionEdge>, Vec<&DecisionEdge>) {
+        let incoming: Vec<_> = self.graph.edges.iter().filter(|e| e.to_node_id == node_id).collect();
+        let outgoing: Vec<_> = self.graph.edges.iter().filter(|e| e.from_node_id == node_id).collect();
+        (incoming, outgoing)
+    }
+
+    /// Get node by ID
+    pub fn get_node_by_id(&self, id: i32) -> Option<&DecisionNode> {
+        self.graph.nodes.iter().find(|n| n.id == id)
+    }
+
+    /// Parse metadata JSON and extract confidence
+    /// Delegates to types::get_confidence for consistency
+    pub fn get_confidence(node: &DecisionNode) -> Option<i32> {
+        types::get_confidence(node)
+    }
+
+    /// Parse metadata and extract commit hash
+    /// Delegates to types::get_commit for consistency
+    pub fn get_commit(node: &DecisionNode) -> Option<String> {
+        types::get_commit(node)
+    }
+
+    /// Parse metadata and extract files
+    /// Delegates to types::get_files for consistency
+    pub fn get_files(node: &DecisionNode) -> Vec<String> {
+        types::get_files(node)
+    }
+
+    /// Parse metadata and extract branch
+    /// Delegates to types::get_branch for consistency
+    pub fn get_branch(node: &DecisionNode) -> Option<String> {
+        types::get_branch(node)
+    }
+
+    // Navigation methods
+    pub fn move_up(&mut self) {
+        if self.selected_index > 0 {
+            self.selected_index -= 1;
+            self.ensure_visible();
+        }
+    }
+
+    pub fn move_down(&mut self) {
+        if self.selected_index + 1 < self.filtered_nodes.len() {
+            self.selected_index += 1;
+            self.ensure_visible();
+        }
+    }
+
+    pub fn jump_to_top(&mut self) {
+        self.selected_index = 0;
+        self.scroll_offset = 0;
+    }
+
+    pub fn jump_to_bottom(&mut self) {
+        if !self.filtered_nodes.is_empty() {
+            self.selected_index = self.filtered_nodes.len() - 1;
+            self.ensure_visible();
+        }
+    }
+
+    pub fn page_down(&mut self) {
+        let page_size = (self.viewport_height as usize).saturating_sub(6);
+        self.selected_index = (self.selected_index + page_size).min(self.filtered_nodes.len().saturating_sub(1));
+        self.ensure_visible();
+    }
+
+    pub fn page_up(&mut self) {
+        let page_size = (self.viewport_height as usize).saturating_sub(6);
+        self.selected_index = self.selected_index.saturating_sub(page_size);
+        self.ensure_visible();
+    }
+
+    fn ensure_visible(&mut self) {
+        let visible_height = (self.viewport_height as usize).saturating_sub(6);
+        let item_height = 3; // Each node takes ~3 lines
+        let visible_items = visible_height / item_height;
+
+        if self.selected_index < self.scroll_offset {
+            self.scroll_offset = self.selected_index;
+        } else if self.selected_index >= self.scroll_offset + visible_items {
+            self.scroll_offset = self.selected_index.saturating_sub(visible_items - 1);
+        }
+    }
+
+    pub fn toggle_view(&mut self) {
+        self.current_view = match self.current_view {
+            View::Timeline => View::Dag,
+            View::Dag => View::Timeline,
+        };
+    }
+
+    pub fn toggle_detail(&mut self) {
+        self.detail_expanded = !self.detail_expanded;
+    }
+
+    pub fn resize(&mut self, width: u16, height: u16) {
+        self.viewport_width = width;
+        self.viewport_height = height;
+    }
+
+    pub fn handle_mouse(&mut self, event: MouseEvent) {
+        match event.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                // TODO: Implement click detection based on areas
+            }
+            MouseEventKind::ScrollDown => {
+                self.move_down();
+            }
+            MouseEventKind::ScrollUp => {
+                self.move_up();
+            }
+            _ => {}
+        }
+    }
+
+    pub fn set_status(&mut self, message: String) {
+        self.status_message = Some((message, Instant::now()));
+    }
+
+    /// Open files in editor
+    pub fn open_files(&mut self, files: Vec<String>) {
+        if files.is_empty() {
+            self.set_status("No files to open".to_string());
+            return;
+        }
+
+        let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vim".to_string());
+
+        // We need to temporarily leave the TUI to open the editor
+        // This is handled by the caller
+        self.set_status(format!("Opening {} file(s) in {}", files.len(), editor));
+    }
+
+    /// Show file picker for multi-file selection
+    pub fn show_file_picker(&mut self, files: Vec<String>) {
+        if files.len() == 1 {
+            // Single file - open directly
+            self.open_files(files);
+        } else if !files.is_empty() {
+            self.file_picker = Some(FilePicker::new(files));
+            self.focus = Focus::FilePicker;
+        }
+    }
+
+    /// Cycle through type filters
+    pub fn cycle_type_filter(&mut self) {
+        let types = ["goal", "decision", "option", "action", "outcome", "observation"];
+        self.type_filter = match &self.type_filter {
+            None => Some(types[0].to_string()),
+            Some(current) => {
+                let idx = types.iter().position(|t| t == current);
+                match idx {
+                    Some(i) if i + 1 < types.len() => Some(types[i + 1].to_string()),
+                    _ => None,
+                }
+            }
+        };
+        self.apply_filters();
+    }
+
+    // DAG navigation
+    pub fn dag_pan(&mut self, dx: i32, dy: i32) {
+        self.dag_offset_x += dx * 5;
+        self.dag_offset_y += dy * 5;
+    }
+
+    pub fn dag_zoom_in(&mut self) {
+        self.dag_zoom = (self.dag_zoom * 1.2).min(3.0);
+    }
+
+    pub fn dag_zoom_out(&mut self) {
+        self.dag_zoom = (self.dag_zoom / 1.2).max(0.3);
+    }
+
+    pub fn dag_reset_zoom(&mut self) {
+        self.dag_zoom = 1.0;
+        self.dag_offset_x = 0;
+        self.dag_offset_y = 0;
+    }
+}

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -1,0 +1,262 @@
+//! Event handling for the TUI
+//!
+//! Implements vim-style keybindings and mode switching
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use super::app::{App, Focus, Mode, View};
+
+/// Handle a key event, returns true if app should quit
+pub fn handle_event(app: &mut App, key: KeyEvent) -> bool {
+    // Handle help overlay first
+    if app.show_help {
+        if matches!(key.code, KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?')) {
+            app.show_help = false;
+        }
+        return false;
+    }
+
+    // Handle file picker
+    if app.focus == Focus::FilePicker {
+        return handle_file_picker(app, key);
+    }
+
+    // Handle based on mode
+    match app.mode {
+        Mode::Search => handle_search_mode(app, key),
+        Mode::Normal => handle_normal_mode(app, key),
+        Mode::Command => handle_command_mode(app, key),
+    }
+}
+
+fn handle_search_mode(app: &mut App, key: KeyEvent) -> bool {
+    match key.code {
+        KeyCode::Esc => {
+            app.mode = Mode::Normal;
+            app.search_query.clear();
+            app.apply_filters();
+        }
+        KeyCode::Enter => {
+            app.mode = Mode::Normal;
+            app.focus = Focus::List;
+        }
+        KeyCode::Backspace => {
+            app.search_query.pop();
+            app.apply_filters();
+        }
+        KeyCode::Char(c) => {
+            app.search_query.push(c);
+            app.apply_filters();
+        }
+        _ => {}
+    }
+    false
+}
+
+fn handle_command_mode(app: &mut App, key: KeyEvent) -> bool {
+    match key.code {
+        KeyCode::Esc => {
+            app.mode = Mode::Normal;
+        }
+        _ => {}
+    }
+    false
+}
+
+fn handle_normal_mode(app: &mut App, key: KeyEvent) -> bool {
+    // Check for 'g' prefix first
+    if app.pending_g {
+        app.pending_g = false;
+        match key.code {
+            KeyCode::Char('g') => {
+                // gg - jump to top
+                app.jump_to_top();
+                return false;
+            }
+            _ => {
+                // Invalid g-sequence, ignore
+                return false;
+            }
+        }
+    }
+
+    match app.current_view {
+        View::Timeline => handle_timeline_keys(app, key),
+        View::Dag => handle_dag_keys(app, key),
+    }
+}
+
+fn handle_timeline_keys(app: &mut App, key: KeyEvent) -> bool {
+    match key.code {
+        // Quit
+        KeyCode::Char('q') => return true,
+
+        // Help
+        KeyCode::Char('?') => {
+            app.show_help = true;
+        }
+
+        // Navigation
+        KeyCode::Char('j') | KeyCode::Down => app.move_down(),
+        KeyCode::Char('k') | KeyCode::Up => app.move_up(),
+        KeyCode::Char('g') => {
+            app.pending_g = true;
+        }
+        KeyCode::Char('G') => app.jump_to_bottom(),
+
+        // Page navigation
+        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => app.page_down(),
+        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => app.page_up(),
+        KeyCode::PageDown => app.page_down(),
+        KeyCode::PageUp => app.page_up(),
+
+        // Search
+        KeyCode::Char('/') => {
+            app.mode = Mode::Search;
+            app.focus = Focus::Search;
+            app.search_query.clear();
+        }
+
+        // Filter by type
+        KeyCode::Char('f') => {
+            app.cycle_type_filter();
+        }
+
+        // Clear filters
+        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.type_filter = None;
+            app.branch_filter = None;
+            app.search_query.clear();
+            app.apply_filters();
+        }
+
+        // Toggle detail panel
+        KeyCode::Enter => {
+            app.toggle_detail();
+        }
+
+        // Open files in editor
+        KeyCode::Char('o') => {
+            if let Some(node) = app.selected_node() {
+                let files = App::get_files(node);
+                if !files.is_empty() {
+                    app.show_file_picker(files);
+                } else {
+                    app.set_status("No files associated with this node".to_string());
+                }
+            }
+        }
+
+        // Open commit
+        KeyCode::Char('O') => {
+            if let Some(node) = app.selected_node() {
+                if let Some(commit) = App::get_commit(node) {
+                    app.set_status(format!("Opening commit: {}", commit));
+                    // TODO: Actually open git show
+                } else {
+                    app.set_status("No commit associated with this node".to_string());
+                }
+            }
+        }
+
+        // Refresh
+        KeyCode::Char('r') => {
+            if let Err(e) = app.reload_graph() {
+                app.set_status(format!("Refresh failed: {}", e));
+            } else {
+                app.show_refresh_indicator();
+            }
+        }
+
+        // Switch view
+        KeyCode::Tab => app.toggle_view(),
+
+        // Escape clears selection or exits modes
+        KeyCode::Esc => {
+            if app.detail_expanded {
+                app.detail_expanded = false;
+            }
+        }
+
+        _ => {}
+    }
+    false
+}
+
+fn handle_dag_keys(app: &mut App, key: KeyEvent) -> bool {
+    match key.code {
+        // Quit
+        KeyCode::Char('q') => return true,
+
+        // Help
+        KeyCode::Char('?') => {
+            app.show_help = true;
+        }
+
+        // Pan
+        KeyCode::Char('h') | KeyCode::Left => app.dag_pan(-1, 0),
+        KeyCode::Char('j') | KeyCode::Down => app.dag_pan(0, 1),
+        KeyCode::Char('k') | KeyCode::Up => app.dag_pan(0, -1),
+        KeyCode::Char('l') | KeyCode::Right => app.dag_pan(1, 0),
+
+        // Zoom
+        KeyCode::Char('+') | KeyCode::Char('=') => app.dag_zoom_in(),
+        KeyCode::Char('-') => app.dag_zoom_out(),
+        KeyCode::Char('0') => app.dag_reset_zoom(),
+
+        // Switch view
+        KeyCode::Tab => app.toggle_view(),
+
+        // Refresh
+        KeyCode::Char('r') => {
+            if let Err(e) = app.reload_graph() {
+                app.set_status(format!("Refresh failed: {}", e));
+            } else {
+                app.show_refresh_indicator();
+            }
+        }
+
+        KeyCode::Esc => {}
+
+        _ => {}
+    }
+    false
+}
+
+fn handle_file_picker(app: &mut App, key: KeyEvent) -> bool {
+    if let Some(ref mut picker) = app.file_picker {
+        match key.code {
+            KeyCode::Esc => {
+                app.file_picker = None;
+                app.focus = Focus::List;
+            }
+            KeyCode::Char('j') | KeyCode::Down => picker.move_down(),
+            KeyCode::Char('k') | KeyCode::Up => picker.move_up(),
+            KeyCode::Char(' ') => picker.toggle_current(),
+            KeyCode::Enter => {
+                let selected = picker.get_selected_files();
+                let files = if selected.is_empty() {
+                    // If nothing selected, use current cursor item
+                    vec![picker.files[picker.cursor].clone()]
+                } else {
+                    selected
+                };
+                app.file_picker = None;
+                app.focus = Focus::List;
+                app.open_files(files);
+            }
+            KeyCode::Char('a') => {
+                // Select all
+                for sel in picker.selected.iter_mut() {
+                    *sel = true;
+                }
+            }
+            KeyCode::Char('q') => {
+                app.file_picker = None;
+                app.focus = Focus::List;
+            }
+            _ => {}
+        }
+    }
+    false
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,0 +1,121 @@
+//! Terminal User Interface for Deciduous
+//!
+//! A rich TUI for exploring and navigating the decision graph.
+//! Features:
+//! - Timeline view with vim-style navigation
+//! - DAG visualization with hierarchical layout
+//! - Node detail panel with code jumping
+//! - Auto-refresh on database changes
+
+pub mod app;
+pub mod events;
+pub mod types;
+pub mod ui;
+pub mod views;
+pub mod widgets;
+
+use std::io;
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use crossterm::{
+    event::{poll, read, DisableMouseCapture, EnableMouseCapture, Event},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
+use ratatui::prelude::*;
+
+use app::App;
+use events::handle_event;
+
+/// Run the TUI application
+pub fn run(db_path: Option<PathBuf>) -> Result<(), Box<dyn std::error::Error>> {
+    // Setup terminal
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    // Create app state
+    let mut app = App::new(db_path)?;
+
+    // Setup file watcher for auto-refresh
+    let (tx, rx) = mpsc::channel();
+    let db_path_for_watcher = app.db_path().to_path_buf();
+
+    let mut watcher = RecommendedWatcher::new(
+        move |res: Result<notify::Event, notify::Error>| {
+            if let Ok(event) = res {
+                if event.kind.is_modify() {
+                    let _ = tx.send(());
+                }
+            }
+        },
+        Config::default(),
+    )?;
+
+    // Watch the database file
+    watcher.watch(&db_path_for_watcher, RecursiveMode::NonRecursive)?;
+
+    // Run the main loop
+    let result = run_app(&mut terminal, &mut app, rx);
+
+    // Restore terminal
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    terminal.show_cursor()?;
+
+    result
+}
+
+fn run_app<B: Backend>(
+    terminal: &mut Terminal<B>,
+    app: &mut App,
+    file_change_rx: mpsc::Receiver<()>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let tick_rate = Duration::from_millis(100);
+    let mut last_tick = Instant::now();
+
+    loop {
+        // Draw the UI
+        terminal.draw(|f| ui::draw(f, app))?;
+
+        // Handle input with timeout
+        let timeout = tick_rate.saturating_sub(last_tick.elapsed());
+        if poll(timeout)? {
+            match read()? {
+                Event::Key(key) => {
+                    if handle_event(app, key) {
+                        return Ok(()); // Quit signal
+                    }
+                }
+                Event::Mouse(mouse) => {
+                    app.handle_mouse(mouse);
+                }
+                Event::Resize(width, height) => {
+                    app.resize(width, height);
+                }
+                _ => {}
+            }
+        }
+
+        // Check for file changes (non-blocking)
+        if file_change_rx.try_recv().is_ok() {
+            app.reload_graph()?;
+            app.show_refresh_indicator();
+        }
+
+        // Tick for animations/updates
+        if last_tick.elapsed() >= tick_rate {
+            app.tick();
+            last_tick = Instant::now();
+        }
+    }
+}

--- a/src/tui/types.rs
+++ b/src/tui/types.rs
@@ -1,0 +1,346 @@
+//! TUI Type Definitions
+//!
+//! These types mirror the React/TypeScript types in web/src/types/graph.ts
+//! and the Rust backend types in src/db.rs.
+//!
+//! Type Hierarchy:
+//!   - src/db.rs: Database models (Diesel ORM)
+//!   - src/tui/types.rs: TUI view models (this file)
+//!   - web/src/types/graph.ts: Web UI models (TypeScript)
+//!
+//! All three MUST stay in sync for consistent behavior.
+
+use crate::{DecisionNode, DecisionEdge};
+use serde_json::Value;
+
+// =============================================================================
+// Node Types - matches schema CHECK constraint
+// =============================================================================
+
+/// Valid node types in the decision graph
+pub const NODE_TYPES: &[&str] = &["goal", "decision", "option", "action", "outcome", "observation"];
+
+/// Valid node statuses
+pub const NODE_STATUSES: &[&str] = &["pending", "active", "completed", "rejected"];
+
+// =============================================================================
+// Edge Types - matches schema CHECK constraint
+// =============================================================================
+
+/// Valid edge types connecting nodes
+pub const EDGE_TYPES: &[&str] = &["leads_to", "requires", "chosen", "rejected", "blocks", "enables"];
+
+// =============================================================================
+// Metadata - stored as JSON string in metadata_json field
+// =============================================================================
+
+/// Parsed node metadata from metadata_json field
+#[derive(Debug, Clone, Default)]
+pub struct NodeMetadata {
+    /// Confidence score 0-100
+    pub confidence: Option<i32>,
+    /// Git commit hash (full 40 chars)
+    pub commit: Option<String>,
+    /// User prompt that triggered this decision
+    pub prompt: Option<String>,
+    /// Associated files
+    pub files: Vec<String>,
+    /// Git branch this node was created on
+    pub branch: Option<String>,
+}
+
+impl NodeMetadata {
+    /// Parse metadata from JSON string
+    pub fn from_json(json: &str) -> Self {
+        serde_json::from_str::<Value>(json)
+            .ok()
+            .map(|v| Self {
+                confidence: v.get("confidence").and_then(|c| c.as_i64()).map(|c| c as i32),
+                commit: v.get("commit").and_then(|c| c.as_str()).map(|s| s.to_string()),
+                prompt: v.get("prompt").and_then(|p| p.as_str()).map(|s| s.to_string()),
+                files: v.get("files")
+                    .and_then(|f| f.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                branch: v.get("branch").and_then(|b| b.as_str()).map(|s| s.to_string()),
+            })
+            .unwrap_or_default()
+    }
+
+    /// Parse metadata from Option<String>
+    pub fn from_option(json: Option<&String>) -> Self {
+        json.map(|s| Self::from_json(s)).unwrap_or_default()
+    }
+}
+
+// =============================================================================
+// Helper Functions - Mirror web/src/types/graph.ts functions
+// =============================================================================
+
+/// Extract confidence from a node (mirrors getConfidence in TypeScript)
+pub fn get_confidence(node: &DecisionNode) -> Option<i32> {
+    NodeMetadata::from_option(node.metadata_json.as_ref()).confidence
+}
+
+/// Extract commit hash from a node (mirrors getCommit in TypeScript)
+pub fn get_commit(node: &DecisionNode) -> Option<String> {
+    NodeMetadata::from_option(node.metadata_json.as_ref()).commit
+}
+
+/// Extract branch from a node (mirrors getBranch in TypeScript)
+pub fn get_branch(node: &DecisionNode) -> Option<String> {
+    NodeMetadata::from_option(node.metadata_json.as_ref()).branch
+}
+
+/// Extract files from a node (mirrors getFiles in TypeScript)
+pub fn get_files(node: &DecisionNode) -> Vec<String> {
+    NodeMetadata::from_option(node.metadata_json.as_ref()).files
+}
+
+/// Extract prompt from a node (mirrors getPrompt in TypeScript)
+pub fn get_prompt(node: &DecisionNode) -> Option<String> {
+    NodeMetadata::from_option(node.metadata_json.as_ref()).prompt
+}
+
+/// Get short commit hash (7 chars) (mirrors shortCommit in TypeScript)
+pub fn short_commit(commit: &str) -> &str {
+    &commit[..7.min(commit.len())]
+}
+
+/// Get confidence level category (mirrors getConfidenceLevel in TypeScript)
+pub fn get_confidence_level(confidence: Option<i32>) -> Option<&'static str> {
+    confidence.map(|c| {
+        if c >= 70 { "high" }
+        else if c >= 40 { "med" }
+        else { "low" }
+    })
+}
+
+/// Truncate string with ellipsis (mirrors truncate in TypeScript)
+pub fn truncate(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max_len.saturating_sub(3)])
+    }
+}
+
+/// Type guard for valid node type
+pub fn is_node_type(value: &str) -> bool {
+    NODE_TYPES.contains(&value)
+}
+
+/// Type guard for valid edge type
+pub fn is_edge_type(value: &str) -> bool {
+    EDGE_TYPES.contains(&value)
+}
+
+/// Get all unique branches from a list of nodes
+pub fn get_unique_branches(nodes: &[DecisionNode]) -> Vec<String> {
+    let mut branches: Vec<String> = nodes
+        .iter()
+        .filter_map(|n| get_branch(n))
+        .collect();
+    branches.sort();
+    branches.dedup();
+    branches
+}
+
+/// Get incoming edges for a node
+pub fn get_incoming_edges<'a>(node_id: i32, edges: &'a [DecisionEdge]) -> Vec<&'a DecisionEdge> {
+    edges.iter().filter(|e| e.to_node_id == node_id).collect()
+}
+
+/// Get outgoing edges from a node
+pub fn get_outgoing_edges<'a>(node_id: i32, edges: &'a [DecisionEdge]) -> Vec<&'a DecisionEdge> {
+    edges.iter().filter(|e| e.from_node_id == node_id).collect()
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_node(id: i32, node_type: &str, title: &str, metadata_json: Option<&str>) -> DecisionNode {
+        DecisionNode {
+            id,
+            change_id: format!("test-change-{}", id),
+            node_type: node_type.to_string(),
+            title: title.to_string(),
+            description: None,
+            status: "pending".to_string(),
+            created_at: "2024-12-10T12:00:00Z".to_string(),
+            updated_at: "2024-12-10T12:00:00Z".to_string(),
+            metadata_json: metadata_json.map(|s| s.to_string()),
+        }
+    }
+
+    fn make_test_edge(id: i32, from_id: i32, to_id: i32, edge_type: &str) -> DecisionEdge {
+        DecisionEdge {
+            id,
+            from_node_id: from_id,
+            to_node_id: to_id,
+            from_change_id: None,
+            to_change_id: None,
+            edge_type: edge_type.to_string(),
+            weight: Some(1.0),
+            rationale: None,
+            created_at: "2024-12-10T12:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_node_types_valid() {
+        assert!(is_node_type("goal"));
+        assert!(is_node_type("decision"));
+        assert!(is_node_type("option"));
+        assert!(is_node_type("action"));
+        assert!(is_node_type("outcome"));
+        assert!(is_node_type("observation"));
+        assert!(!is_node_type("invalid"));
+        assert!(!is_node_type(""));
+    }
+
+    #[test]
+    fn test_edge_types_valid() {
+        assert!(is_edge_type("leads_to"));
+        assert!(is_edge_type("requires"));
+        assert!(is_edge_type("chosen"));
+        assert!(is_edge_type("rejected"));
+        assert!(is_edge_type("blocks"));
+        assert!(is_edge_type("enables"));
+        assert!(!is_edge_type("invalid"));
+        assert!(!is_edge_type(""));
+    }
+
+    #[test]
+    fn test_metadata_parsing() {
+        let json = r#"{"confidence": 85, "commit": "abc1234", "branch": "main", "files": ["src/foo.rs", "src/bar.rs"]}"#;
+        let meta = NodeMetadata::from_json(json);
+
+        assert_eq!(meta.confidence, Some(85));
+        assert_eq!(meta.commit, Some("abc1234".to_string()));
+        assert_eq!(meta.branch, Some("main".to_string()));
+        assert_eq!(meta.files, vec!["src/foo.rs", "src/bar.rs"]);
+    }
+
+    #[test]
+    fn test_metadata_parsing_empty() {
+        let meta = NodeMetadata::from_json("{}");
+        assert_eq!(meta.confidence, None);
+        assert_eq!(meta.commit, None);
+        assert!(meta.files.is_empty());
+    }
+
+    #[test]
+    fn test_metadata_parsing_invalid() {
+        let meta = NodeMetadata::from_json("not json");
+        assert_eq!(meta.confidence, None);
+    }
+
+    #[test]
+    fn test_get_confidence() {
+        let node = make_test_node(1, "goal", "Test", Some(r#"{"confidence": 90}"#));
+        assert_eq!(get_confidence(&node), Some(90));
+
+        let node_no_meta = make_test_node(2, "goal", "Test", None);
+        assert_eq!(get_confidence(&node_no_meta), None);
+    }
+
+    #[test]
+    fn test_get_commit() {
+        let node = make_test_node(1, "action", "Test", Some(r#"{"commit": "abc1234567890"}"#));
+        assert_eq!(get_commit(&node), Some("abc1234567890".to_string()));
+    }
+
+    #[test]
+    fn test_get_branch() {
+        let node = make_test_node(1, "goal", "Test", Some(r#"{"branch": "feature/test"}"#));
+        assert_eq!(get_branch(&node), Some("feature/test".to_string()));
+    }
+
+    #[test]
+    fn test_get_files() {
+        let node = make_test_node(1, "action", "Test", Some(r#"{"files": ["a.rs", "b.rs"]}"#));
+        assert_eq!(get_files(&node), vec!["a.rs", "b.rs"]);
+
+        let node_no_files = make_test_node(2, "action", "Test", Some(r#"{}"#));
+        assert!(get_files(&node_no_files).is_empty());
+    }
+
+    #[test]
+    fn test_short_commit() {
+        assert_eq!(short_commit("abc1234567890"), "abc1234");
+        assert_eq!(short_commit("abc"), "abc");
+        assert_eq!(short_commit(""), "");
+    }
+
+    #[test]
+    fn test_confidence_level() {
+        assert_eq!(get_confidence_level(Some(90)), Some("high"));
+        assert_eq!(get_confidence_level(Some(70)), Some("high"));
+        assert_eq!(get_confidence_level(Some(69)), Some("med"));
+        assert_eq!(get_confidence_level(Some(40)), Some("med"));
+        assert_eq!(get_confidence_level(Some(39)), Some("low"));
+        assert_eq!(get_confidence_level(Some(0)), Some("low"));
+        assert_eq!(get_confidence_level(None), None);
+    }
+
+    #[test]
+    fn test_truncate() {
+        assert_eq!(truncate("hello", 10), "hello");
+        assert_eq!(truncate("hello world", 8), "hello...");
+        assert_eq!(truncate("", 10), "");
+    }
+
+    #[test]
+    fn test_get_unique_branches() {
+        let nodes = vec![
+            make_test_node(1, "goal", "A", Some(r#"{"branch": "main"}"#)),
+            make_test_node(2, "goal", "B", Some(r#"{"branch": "feature"}"#)),
+            make_test_node(3, "goal", "C", Some(r#"{"branch": "main"}"#)),
+            make_test_node(4, "goal", "D", None),
+        ];
+        let branches = get_unique_branches(&nodes);
+        assert_eq!(branches, vec!["feature", "main"]);
+    }
+
+    #[test]
+    fn test_get_incoming_edges() {
+        let edges = vec![
+            make_test_edge(1, 1, 2, "leads_to"),
+            make_test_edge(2, 1, 3, "leads_to"),
+            make_test_edge(3, 2, 3, "chosen"),
+        ];
+
+        let incoming_to_3 = get_incoming_edges(3, &edges);
+        assert_eq!(incoming_to_3.len(), 2);
+        assert!(incoming_to_3.iter().any(|e| e.from_node_id == 1));
+        assert!(incoming_to_3.iter().any(|e| e.from_node_id == 2));
+
+        let incoming_to_1 = get_incoming_edges(1, &edges);
+        assert!(incoming_to_1.is_empty());
+    }
+
+    #[test]
+    fn test_get_outgoing_edges() {
+        let edges = vec![
+            make_test_edge(1, 1, 2, "leads_to"),
+            make_test_edge(2, 1, 3, "leads_to"),
+            make_test_edge(3, 2, 3, "chosen"),
+        ];
+
+        let outgoing_from_1 = get_outgoing_edges(1, &edges);
+        assert_eq!(outgoing_from_1.len(), 2);
+
+        let outgoing_from_3 = get_outgoing_edges(3, &edges);
+        assert!(outgoing_from_3.is_empty());
+    }
+}

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,0 +1,227 @@
+//! UI rendering for the TUI
+
+use ratatui::{
+    prelude::*,
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+};
+
+use super::app::{App, Mode, View};
+use super::views::{timeline, dag, detail};
+use super::widgets::file_picker;
+
+/// Main draw function - orchestrates all rendering
+pub fn draw(frame: &mut Frame, app: &App) {
+    let area = frame.area();
+
+    // Main layout: header, content, footer
+    let main_layout = Layout::vertical([
+        Constraint::Length(1),  // Header
+        Constraint::Length(1),  // Filter bar
+        Constraint::Min(10),    // Content
+        Constraint::Length(1),  // Footer/status
+    ])
+    .split(area);
+
+    // Draw header
+    draw_header(frame, app, main_layout[0]);
+
+    // Draw filter bar
+    draw_filter_bar(frame, app, main_layout[1]);
+
+    // Draw main content based on view
+    match app.current_view {
+        View::Timeline => {
+            if app.detail_expanded {
+                // Split content horizontally
+                let content_layout = Layout::horizontal([
+                    Constraint::Percentage(50),
+                    Constraint::Percentage(50),
+                ])
+                .split(main_layout[2]);
+
+                timeline::draw(frame, app, content_layout[0]);
+                detail::draw(frame, app, content_layout[1]);
+            } else {
+                timeline::draw(frame, app, main_layout[2]);
+            }
+        }
+        View::Dag => {
+            dag::draw(frame, app, main_layout[2]);
+        }
+    }
+
+    // Draw footer
+    draw_footer(frame, app, main_layout[3]);
+
+    // Draw overlays
+    if app.show_help {
+        draw_help_overlay(frame, area);
+    }
+
+    if app.file_picker.is_some() {
+        file_picker::draw(frame, app, area);
+    }
+}
+
+fn draw_header(frame: &mut Frame, app: &App, area: Rect) {
+    let view_name = match app.current_view {
+        View::Timeline => "Timeline",
+        View::Dag => "DAG",
+    };
+
+    let node_count = app.filtered_nodes.len();
+    let total_nodes = app.graph.nodes.len();
+    let edge_count = app.graph.edges.len();
+
+    let refresh_indicator = if app.refresh_shown_at.is_some() {
+        " [Updated]"
+    } else {
+        ""
+    };
+
+    let header_text = format!(
+        " Deciduous TUI │ {} │ [{}/{} nodes] [{} edges]{}",
+        view_name, node_count, total_nodes, edge_count, refresh_indicator
+    );
+
+    let header = Paragraph::new(header_text)
+        .style(Style::default().bg(Color::Blue).fg(Color::White).bold());
+
+    frame.render_widget(header, area);
+}
+
+fn draw_filter_bar(frame: &mut Frame, app: &App, area: Rect) {
+    let mut spans = vec![Span::raw(" Filters: ")];
+
+    // Type filter buttons
+    let types = ["All", "goal", "decision", "option", "action", "outcome", "observation"];
+    for t in types {
+        let is_active = match &app.type_filter {
+            None => t == "All",
+            Some(f) => f == t,
+        };
+        let style = if is_active {
+            Style::default().fg(Color::Black).bg(Color::Yellow)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+        spans.push(Span::styled(format!("[{}]", t), style));
+        spans.push(Span::raw(" "));
+    }
+
+    // Search indicator
+    if app.mode == Mode::Search || !app.search_query.is_empty() {
+        spans.push(Span::raw("│ Search: "));
+        spans.push(Span::styled(
+            &app.search_query,
+            Style::default().fg(Color::Cyan),
+        ));
+        if app.mode == Mode::Search {
+            spans.push(Span::styled("_", Style::default().fg(Color::Cyan).rapid_blink()));
+        }
+    }
+
+    let filter_bar = Paragraph::new(Line::from(spans))
+        .style(Style::default().bg(Color::DarkGray));
+
+    frame.render_widget(filter_bar, area);
+}
+
+fn draw_footer(frame: &mut Frame, app: &App, area: Rect) {
+    let keybinds = match app.current_view {
+        View::Timeline => {
+            "j/k:move  Enter:detail  o:open-code  /:search  f:filter  Tab:DAG  ?:help  q:quit"
+        }
+        View::Dag => {
+            "h/j/k/l:pan  +/-:zoom  0:reset  Tab:Timeline  ?:help  q:quit"
+        }
+    };
+
+    // Show status message if present, otherwise show keybinds
+    let footer_text = if let Some((ref msg, _)) = app.status_message {
+        msg.clone()
+    } else {
+        keybinds.to_string()
+    };
+
+    let footer = Paragraph::new(format!(" {}", footer_text))
+        .style(Style::default().bg(Color::DarkGray).fg(Color::White));
+
+    frame.render_widget(footer, area);
+}
+
+fn draw_help_overlay(frame: &mut Frame, area: Rect) {
+    // Center the help popup
+    let popup_width = 60.min(area.width.saturating_sub(4));
+    let popup_height = 22.min(area.height.saturating_sub(4));
+
+    let popup_area = Rect {
+        x: (area.width - popup_width) / 2,
+        y: (area.height - popup_height) / 2,
+        width: popup_width,
+        height: popup_height,
+    };
+
+    // Clear the background
+    frame.render_widget(Clear, popup_area);
+
+    let help_text = r#"
+  Timeline View
+  ─────────────────────────────────
+  j/k, ↑/↓     Move up/down
+  gg           Jump to top
+  G            Jump to bottom
+  Ctrl+d/u     Page down/up
+  Enter        Toggle detail panel
+  o            Open associated files
+  O            Open commit in git
+  /            Search
+  f            Cycle type filter
+  Ctrl+c       Clear all filters
+  Tab          Switch to DAG view
+  r            Refresh
+  q            Quit
+
+  DAG View
+  ─────────────────────────────────
+  h/j/k/l      Pan view
+  +/-          Zoom in/out
+  0            Reset zoom
+  Tab          Switch to Timeline
+
+  Press ? or Esc to close
+"#;
+
+    let help = Paragraph::new(help_text)
+        .block(
+            Block::default()
+                .title(" Help ")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan)),
+        )
+        .wrap(Wrap { trim: false })
+        .style(Style::default().fg(Color::White).bg(Color::Black));
+
+    frame.render_widget(help, popup_area);
+}
+
+/// Get color for node type
+pub fn node_type_color(node_type: &str) -> Color {
+    match node_type {
+        "goal" => Color::Green,
+        "decision" => Color::Yellow,
+        "option" => Color::Magenta,
+        "action" => Color::Red,
+        "outcome" => Color::Cyan,
+        "observation" => Color::Blue,
+        _ => Color::White,
+    }
+}
+
+/// Get style for node type badge
+pub fn node_type_style(node_type: &str) -> Style {
+    Style::default()
+        .fg(Color::Black)
+        .bg(node_type_color(node_type))
+        .bold()
+}

--- a/src/tui/views/dag.rs
+++ b/src/tui/views/dag.rs
@@ -1,0 +1,240 @@
+//! DAG View - Hierarchical graph visualization
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use ratatui::{
+    prelude::*,
+    widgets::{Block, Borders, Paragraph, canvas::{Canvas, Line as CanvasLine, Rectangle}},
+};
+
+use crate::tui::app::App;
+use crate::tui::ui::node_type_color;
+use crate::DecisionNode;
+
+/// Node position in the DAG layout
+#[derive(Debug, Clone)]
+struct NodePosition {
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+    node_id: i32,
+}
+
+/// Draw the DAG view
+pub fn draw(frame: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default()
+        .title(format!(
+            " DAG │ zoom: {}% │ [+/-] zoom  [h/j/k/l] pan  [0] reset ",
+            (app.dag_zoom * 100.0) as i32
+        ))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Magenta));
+
+    let inner_area = block.inner(area);
+    frame.render_widget(block, area);
+
+    if app.graph.nodes.is_empty() {
+        let empty = Paragraph::new("No nodes in graph")
+            .style(Style::default().fg(Color::DarkGray))
+            .alignment(Alignment::Center);
+        frame.render_widget(empty, inner_area);
+        return;
+    }
+
+    // Calculate hierarchical layout
+    let positions = calculate_layout(&app.graph.nodes, &app.graph.edges, app);
+
+    // Draw using canvas
+    let canvas = Canvas::default()
+        .x_bounds([
+            app.dag_offset_x as f64 - (inner_area.width as f64 / 2.0) / app.dag_zoom as f64,
+            app.dag_offset_x as f64 + (inner_area.width as f64 / 2.0) / app.dag_zoom as f64,
+        ])
+        .y_bounds([
+            app.dag_offset_y as f64 - (inner_area.height as f64) / app.dag_zoom as f64,
+            app.dag_offset_y as f64 + (inner_area.height as f64) / app.dag_zoom as f64,
+        ])
+        .paint(|ctx| {
+            // Draw edges first (behind nodes)
+            for edge in &app.graph.edges {
+                let from_pos = positions.iter().find(|p| p.node_id == edge.from_node_id);
+                let to_pos = positions.iter().find(|p| p.node_id == edge.to_node_id);
+
+                if let (Some(from), Some(to)) = (from_pos, to_pos) {
+                    let color = match edge.edge_type.as_str() {
+                        "chosen" => Color::Green,
+                        "rejected" => Color::Red,
+                        "blocks" => Color::Red,
+                        "enables" => Color::Cyan,
+                        _ => Color::DarkGray,
+                    };
+
+                    // Draw line from bottom of source to top of target
+                    ctx.draw(&CanvasLine {
+                        x1: from.x + from.width / 2.0,
+                        y1: from.y - from.height,
+                        x2: to.x + to.width / 2.0,
+                        y2: to.y,
+                        color,
+                    });
+                }
+            }
+
+            // Draw nodes
+            for pos in &positions {
+                if let Some(node) = app.graph.nodes.iter().find(|n| n.id == pos.node_id) {
+                    let color = node_type_color(&node.node_type);
+
+                    // Draw node box
+                    ctx.draw(&Rectangle {
+                        x: pos.x,
+                        y: pos.y - pos.height,
+                        width: pos.width,
+                        height: pos.height,
+                        color,
+                    });
+
+                    // Draw node label (type abbreviation)
+                    let label = format!(
+                        "{}",
+                        node.node_type.chars().next().unwrap_or('?').to_uppercase()
+                    );
+                    ctx.print(pos.x + 1.0, pos.y - pos.height / 2.0, label);
+                }
+            }
+        });
+
+    frame.render_widget(canvas, inner_area);
+
+    // Draw legend in corner
+    let legend_area = Rect {
+        x: inner_area.x + inner_area.width.saturating_sub(25),
+        y: inner_area.y,
+        width: 24,
+        height: 8,
+    };
+
+    let legend_text = vec![
+        Line::from(vec![
+            Span::styled("■", Style::default().fg(Color::Green)),
+            Span::raw(" goal"),
+        ]),
+        Line::from(vec![
+            Span::styled("■", Style::default().fg(Color::Yellow)),
+            Span::raw(" decision"),
+        ]),
+        Line::from(vec![
+            Span::styled("■", Style::default().fg(Color::Magenta)),
+            Span::raw(" option"),
+        ]),
+        Line::from(vec![
+            Span::styled("■", Style::default().fg(Color::Red)),
+            Span::raw(" action"),
+        ]),
+        Line::from(vec![
+            Span::styled("■", Style::default().fg(Color::Cyan)),
+            Span::raw(" outcome"),
+        ]),
+        Line::from(vec![
+            Span::styled("■", Style::default().fg(Color::Blue)),
+            Span::raw(" observation"),
+        ]),
+    ];
+
+    let legend = Paragraph::new(legend_text)
+        .style(Style::default().bg(Color::Black));
+    frame.render_widget(legend, legend_area);
+}
+
+/// Calculate hierarchical layout positions for nodes
+fn calculate_layout(
+    nodes: &[DecisionNode],
+    edges: &[crate::DecisionEdge],
+    _app: &App,
+) -> Vec<NodePosition> {
+    if nodes.is_empty() {
+        return vec![];
+    }
+
+    // Build adjacency lists
+    let mut children: HashMap<i32, Vec<i32>> = HashMap::new();
+    let mut parents: HashMap<i32, Vec<i32>> = HashMap::new();
+
+    for edge in edges {
+        children.entry(edge.from_node_id).or_default().push(edge.to_node_id);
+        parents.entry(edge.to_node_id).or_default().push(edge.from_node_id);
+    }
+
+    // Find root nodes (no incoming edges)
+    let all_node_ids: HashSet<i32> = nodes.iter().map(|n| n.id).collect();
+    let has_parent: HashSet<i32> = edges.iter().map(|e| e.to_node_id).collect();
+    let roots: Vec<i32> = all_node_ids.difference(&has_parent).cloned().collect();
+
+    // Assign levels using BFS from roots
+    let mut levels: HashMap<i32, usize> = HashMap::new();
+    let mut queue: VecDeque<(i32, usize)> = VecDeque::new();
+
+    for root in &roots {
+        queue.push_back((*root, 0));
+        levels.insert(*root, 0);
+    }
+
+    // For orphan nodes (no edges at all), assign level 0
+    for node in nodes {
+        if !levels.contains_key(&node.id) {
+            levels.insert(node.id, 0);
+        }
+    }
+
+    while let Some((node_id, level)) = queue.pop_front() {
+        if let Some(child_ids) = children.get(&node_id) {
+            for &child_id in child_ids {
+                let new_level = level + 1;
+                let current = levels.get(&child_id).cloned().unwrap_or(0);
+                if new_level > current {
+                    levels.insert(child_id, new_level);
+                    queue.push_back((child_id, new_level));
+                }
+            }
+        }
+    }
+
+    // Group nodes by level
+    let mut level_groups: HashMap<usize, Vec<i32>> = HashMap::new();
+    for (node_id, level) in &levels {
+        level_groups.entry(*level).or_default().push(*node_id);
+    }
+
+    // Calculate positions
+    let node_width = 12.0;
+    let node_height = 4.0;
+    let h_spacing = 16.0;
+    let v_spacing = 8.0;
+
+    let max_level = levels.values().max().cloned().unwrap_or(0);
+
+    let mut positions = Vec::new();
+
+    for (level, node_ids) in &level_groups {
+        let count = node_ids.len();
+        let total_width = count as f64 * (node_width + h_spacing) - h_spacing;
+        let start_x = -total_width / 2.0;
+
+        for (i, &node_id) in node_ids.iter().enumerate() {
+            let x = start_x + i as f64 * (node_width + h_spacing);
+            // Invert Y so roots are at top (higher Y in canvas = lower on screen)
+            let y = (max_level - *level) as f64 * (node_height + v_spacing);
+
+            positions.push(NodePosition {
+                x,
+                y,
+                width: node_width,
+                height: node_height,
+                node_id,
+            });
+        }
+    }
+
+    positions
+}

--- a/src/tui/views/detail.rs
+++ b/src/tui/views/detail.rs
@@ -1,0 +1,259 @@
+//! Detail panel view - shows full node information
+
+use ratatui::{
+    prelude::*,
+    widgets::{Block, Borders, Paragraph, Wrap},
+};
+
+use crate::tui::app::App;
+use crate::tui::ui::{node_type_color, node_type_style};
+
+/// Draw the detail panel for the selected node
+pub fn draw(frame: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default()
+        .title(" Detail ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let inner_area = block.inner(area);
+    frame.render_widget(block, area);
+
+    let Some(node) = app.selected_node() else {
+        let empty = Paragraph::new("Select a node to view details")
+            .style(Style::default().fg(Color::DarkGray))
+            .alignment(Alignment::Center);
+        frame.render_widget(empty, inner_area);
+        return;
+    };
+
+    // Get metadata
+    let confidence = App::get_confidence(node);
+    let commit = App::get_commit(node);
+    let files = App::get_files(node);
+    let branch = App::get_branch(node);
+
+    // Build content lines
+    let mut lines: Vec<Line> = vec![];
+
+    // Type badge with confidence
+    let mut header_spans = vec![
+        Span::styled(
+            format!(" {} ", node.node_type.to_uppercase()),
+            node_type_style(&node.node_type),
+        ),
+        Span::raw(" "),
+    ];
+
+    if let Some(conf) = confidence {
+        let conf_color = if conf >= 90 {
+            Color::Green
+        } else if conf >= 70 {
+            Color::Yellow
+        } else {
+            Color::Red
+        };
+        header_spans.push(Span::styled(
+            format!("{}%", conf),
+            Style::default().fg(conf_color).bold(),
+        ));
+    }
+
+    lines.push(Line::from(header_spans));
+    lines.push(Line::from(""));
+
+    // Title
+    lines.push(Line::from(Span::styled(
+        &node.title,
+        Style::default().fg(Color::White).bold(),
+    )));
+    lines.push(Line::from(""));
+
+    // Description
+    if let Some(ref desc) = node.description {
+        if !desc.is_empty() {
+            for line in desc.lines() {
+                lines.push(Line::from(Span::styled(
+                    line,
+                    Style::default().fg(Color::Gray),
+                )));
+            }
+            lines.push(Line::from(""));
+        }
+    }
+
+    // Metadata section
+    lines.push(Line::from(Span::styled(
+        format!("ID: {} │ {} │ {}", node.id, node.status, format_date(&node.created_at)),
+        Style::default().fg(Color::DarkGray),
+    )));
+    lines.push(Line::from(""));
+
+    // Separator
+    lines.push(Line::from(Span::styled(
+        "─".repeat(inner_area.width as usize - 2),
+        Style::default().fg(Color::DarkGray),
+    )));
+
+    // Connections
+    let (incoming, outgoing) = app.get_node_edges(node.id);
+
+    // Incoming edges
+    lines.push(Line::from(Span::styled(
+        format!("Incoming ({})", incoming.len()),
+        Style::default().fg(Color::Cyan).bold(),
+    )));
+
+    for edge in incoming.iter().take(5) {
+        if let Some(from_node) = app.get_node_by_id(edge.from_node_id) {
+            let type_color = node_type_color(&from_node.node_type);
+            lines.push(Line::from(vec![
+                Span::styled("← ", Style::default().fg(Color::Cyan)),
+                Span::styled(
+                    format!("[{}] ", from_node.node_type.chars().next().unwrap_or('?').to_uppercase()),
+                    Style::default().fg(type_color),
+                ),
+                Span::styled(
+                    truncate_str(&from_node.title, inner_area.width as usize - 10),
+                    Style::default().fg(Color::White),
+                ),
+            ]));
+
+            // Show rationale if present
+            if let Some(ref rationale) = edge.rationale {
+                if !rationale.is_empty() {
+                    lines.push(Line::from(Span::styled(
+                        format!("  {}", truncate_str(rationale, inner_area.width as usize - 6)),
+                        Style::default().fg(Color::DarkGray).italic(),
+                    )));
+                }
+            }
+        }
+    }
+    if incoming.len() > 5 {
+        lines.push(Line::from(Span::styled(
+            format!("  ... and {} more", incoming.len() - 5),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    lines.push(Line::from(""));
+
+    // Outgoing edges
+    lines.push(Line::from(Span::styled(
+        format!("Outgoing ({})", outgoing.len()),
+        Style::default().fg(Color::Yellow).bold(),
+    )));
+
+    for edge in outgoing.iter().take(5) {
+        if let Some(to_node) = app.get_node_by_id(edge.to_node_id) {
+            let type_color = node_type_color(&to_node.node_type);
+            let edge_style = match edge.edge_type.as_str() {
+                "chosen" => Style::default().fg(Color::Green).bold(),
+                "rejected" => Style::default().fg(Color::Red),
+                _ => Style::default().fg(Color::Yellow),
+            };
+
+            lines.push(Line::from(vec![
+                Span::styled("→ ", edge_style),
+                Span::styled(
+                    format!("[{}] ", to_node.node_type.chars().next().unwrap_or('?').to_uppercase()),
+                    Style::default().fg(type_color),
+                ),
+                Span::styled(
+                    truncate_str(&to_node.title, inner_area.width as usize - 10),
+                    Style::default().fg(Color::White),
+                ),
+            ]));
+
+            // Show rationale if present
+            if let Some(ref rationale) = edge.rationale {
+                if !rationale.is_empty() {
+                    lines.push(Line::from(Span::styled(
+                        format!("  {}", truncate_str(rationale, inner_area.width as usize - 6)),
+                        Style::default().fg(Color::DarkGray).italic(),
+                    )));
+                }
+            }
+        }
+    }
+    if outgoing.len() > 5 {
+        lines.push(Line::from(Span::styled(
+            format!("  ... and {} more", outgoing.len() - 5),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    lines.push(Line::from(""));
+
+    // Separator
+    lines.push(Line::from(Span::styled(
+        "─".repeat(inner_area.width as usize - 2),
+        Style::default().fg(Color::DarkGray),
+    )));
+
+    // Files
+    if !files.is_empty() {
+        lines.push(Line::from(Span::styled(
+            format!("Files: {}", files.join(", ")),
+            Style::default().fg(Color::Magenta),
+        )));
+    }
+
+    // Commit
+    if let Some(ref hash) = commit {
+        lines.push(Line::from(vec![
+            Span::styled("Commit: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(hash, Style::default().fg(Color::Yellow)),
+        ]));
+    }
+
+    // Branch
+    if let Some(ref br) = branch {
+        lines.push(Line::from(vec![
+            Span::styled("Branch: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(br, Style::default().fg(Color::Green)),
+        ]));
+    }
+
+    lines.push(Line::from(""));
+
+    // Action hints
+    if !files.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "[o] Open in editor",
+            Style::default().fg(Color::Cyan),
+        )));
+    }
+    if commit.is_some() {
+        lines.push(Line::from(Span::styled(
+            "[O] View commit",
+            Style::default().fg(Color::Cyan),
+        )));
+    }
+    lines.push(Line::from(Span::styled(
+        "[Enter] Toggle panel",
+        Style::default().fg(Color::Cyan),
+    )));
+
+    let detail = Paragraph::new(lines)
+        .wrap(Wrap { trim: false })
+        .scroll((app.detail_scroll as u16, 0));
+
+    frame.render_widget(detail, inner_area);
+}
+
+fn truncate_str(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max_len.saturating_sub(3)])
+    }
+}
+
+fn format_date(ts: &str) -> String {
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(ts) {
+        dt.format("%m/%d/%y").to_string()
+    } else {
+        ts.split('T').next().unwrap_or(ts).to_string()
+    }
+}

--- a/src/tui/views/mod.rs
+++ b/src/tui/views/mod.rs
@@ -1,0 +1,5 @@
+//! TUI Views
+
+pub mod timeline;
+pub mod dag;
+pub mod detail;

--- a/src/tui/views/timeline.rs
+++ b/src/tui/views/timeline.rs
@@ -1,0 +1,171 @@
+//! Timeline view - scrollable list of nodes with details
+
+use ratatui::{
+    prelude::*,
+    widgets::{Block, Borders, List, ListItem, ListState},
+};
+
+use crate::tui::app::App;
+use crate::tui::ui::node_type_style;
+
+/// Draw the timeline view (node list)
+pub fn draw(frame: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default()
+        .title(" Timeline ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Blue));
+
+    let inner_area = block.inner(area);
+    frame.render_widget(block, area);
+
+    if app.filtered_nodes.is_empty() {
+        let empty = ratatui::widgets::Paragraph::new("No nodes match your filters")
+            .style(Style::default().fg(Color::DarkGray))
+            .alignment(Alignment::Center);
+        frame.render_widget(empty, inner_area);
+        return;
+    }
+
+    // Build list items
+    let items: Vec<ListItem> = app
+        .filtered_nodes
+        .iter()
+        .enumerate()
+        .skip(app.scroll_offset)
+        .take(inner_area.height as usize)
+        .map(|(idx, node)| {
+            let is_selected = idx == app.selected_index;
+
+            // Build the node display
+            let confidence = App::get_confidence(node);
+            let commit = App::get_commit(node);
+
+            // First line: type badge, confidence, commit hash
+            let mut line1_spans = vec![
+                Span::styled(
+                    format!(" {} ", node.node_type.to_uppercase()),
+                    node_type_style(&node.node_type),
+                ),
+                Span::raw(" "),
+            ];
+
+            if let Some(conf) = confidence {
+                let conf_color = if conf >= 90 {
+                    Color::Green
+                } else if conf >= 70 {
+                    Color::Yellow
+                } else {
+                    Color::Red
+                };
+                line1_spans.push(Span::styled(
+                    format!("{}%", conf),
+                    Style::default().fg(conf_color),
+                ));
+                line1_spans.push(Span::raw(" "));
+            }
+
+            if let Some(ref hash) = commit {
+                line1_spans.push(Span::styled(
+                    format!("#{}", &hash[..7.min(hash.len())]),
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+
+            // Second line: title (truncated)
+            let title = truncate_str(&node.title, inner_area.width as usize - 4);
+
+            // Third line: timestamp
+            let timestamp = format_timestamp(&node.created_at);
+
+            let content = vec![
+                Line::from(line1_spans),
+                Line::from(Span::styled(
+                    format!("  {}", title),
+                    if is_selected {
+                        Style::default().fg(Color::White).bold()
+                    } else {
+                        Style::default().fg(Color::White)
+                    },
+                )),
+                Line::from(Span::styled(
+                    format!("  {}", timestamp),
+                    Style::default().fg(Color::DarkGray),
+                )),
+            ];
+
+            let style = if is_selected {
+                Style::default().bg(Color::DarkGray)
+            } else {
+                Style::default()
+            };
+
+            ListItem::new(content).style(style)
+        })
+        .collect();
+
+    let list = List::new(items);
+
+    // Create list state for highlighting
+    let mut state = ListState::default();
+    state.select(Some(app.selected_index.saturating_sub(app.scroll_offset)));
+
+    frame.render_stateful_widget(list, inner_area, &mut state);
+
+    // Draw scroll indicator if there are more items
+    if app.filtered_nodes.len() > inner_area.height as usize {
+        let scroll_pos = if app.filtered_nodes.is_empty() {
+            0
+        } else {
+            (app.scroll_offset * (inner_area.height as usize - 1))
+                / app.filtered_nodes.len()
+        };
+
+        // Simple scroll bar on the right edge
+        for i in 0..inner_area.height {
+            let is_thumb = i as usize == scroll_pos;
+            let char = if is_thumb { '█' } else { '│' };
+            let style = if is_thumb {
+                Style::default().fg(Color::Cyan)
+            } else {
+                Style::default().fg(Color::DarkGray)
+            };
+
+            let cell = ratatui::buffer::Cell::default()
+                .set_char(char)
+                .set_style(style)
+                .clone();
+
+            if area.x + area.width > 0 {
+                let x = area.x + area.width - 1;
+                let y = inner_area.y + i;
+                if y < area.y + area.height - 1 {
+                    frame.buffer_mut()[(x, y)] = cell;
+                }
+            }
+        }
+    }
+}
+
+fn truncate_str(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max_len.saturating_sub(3)])
+    }
+}
+
+fn format_timestamp(ts: &str) -> String {
+    // Parse ISO 8601 and format nicely
+    // Input: "2024-12-10T18:04:00Z"
+    // Output: "Dec 10 6:04 PM"
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(ts) {
+        dt.format("%b %d %l:%M %p").to_string()
+    } else {
+        // Try without timezone
+        if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(ts, "%Y-%m-%dT%H:%M:%S") {
+            dt.format("%b %d %l:%M %p").to_string()
+        } else {
+            ts.to_string()
+        }
+    }
+}

--- a/src/tui/widgets/file_picker.rs
+++ b/src/tui/widgets/file_picker.rs
@@ -1,0 +1,75 @@
+//! File picker widget with multi-select checkboxes
+
+use ratatui::{
+    prelude::*,
+    widgets::{Block, Borders, Clear, List, ListItem},
+};
+
+use crate::tui::app::App;
+
+/// Draw the file picker overlay
+pub fn draw(frame: &mut Frame, app: &App, area: Rect) {
+    let Some(ref picker) = app.file_picker else {
+        return;
+    };
+
+    // Calculate popup size
+    let max_file_len = picker.files.iter().map(|f| f.len()).max().unwrap_or(20);
+    let popup_width = (max_file_len + 10).min(60).max(30) as u16;
+    let popup_height = (picker.files.len() + 4).min(20) as u16;
+
+    let popup_area = Rect {
+        x: (area.width.saturating_sub(popup_width)) / 2,
+        y: (area.height.saturating_sub(popup_height)) / 2,
+        width: popup_width,
+        height: popup_height,
+    };
+
+    // Clear background
+    frame.render_widget(Clear, popup_area);
+
+    let block = Block::default()
+        .title(" Select Files (Space=toggle, Enter=open, a=all) ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let inner_area = block.inner(popup_area);
+    frame.render_widget(block, popup_area);
+
+    // Build list items with checkboxes
+    let items: Vec<ListItem> = picker
+        .files
+        .iter()
+        .enumerate()
+        .map(|(i, file)| {
+            let is_selected = picker.selected[i];
+            let is_cursor = i == picker.cursor;
+
+            let checkbox = if is_selected { "[x]" } else { "[ ]" };
+
+            let style = if is_cursor {
+                Style::default().bg(Color::DarkGray).fg(Color::White)
+            } else if is_selected {
+                Style::default().fg(Color::Green)
+            } else {
+                Style::default().fg(Color::White)
+            };
+
+            ListItem::new(Line::from(vec![
+                Span::styled(
+                    checkbox,
+                    if is_selected {
+                        Style::default().fg(Color::Green)
+                    } else {
+                        Style::default().fg(Color::DarkGray)
+                    },
+                ),
+                Span::raw(" "),
+                Span::styled(file, style),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items);
+    frame.render_widget(list, inner_area);
+}

--- a/src/tui/widgets/mod.rs
+++ b/src/tui/widgets/mod.rs
@@ -1,0 +1,3 @@
+//! TUI Widgets
+
+pub mod file_picker;


### PR DESCRIPTION
## Summary

Implements a rich, interactive Terminal UI for exploring and navigating the decision graph. This is a first-class TUI experience with vim-style navigation, auto-refresh, and code jumping.

### Two Primary Views

**Timeline View (Primary)**
- Scrollable list of nodes, newest first
- Type badges with color coding (goal=green, decision=yellow, option=magenta, action=red, outcome=cyan, observation=blue)
- Confidence percentage display
- Vim-style navigation (j/k, gg, G, Ctrl+d/u)
- Search filtering with `/` key
- Type filtering with `f` key
- Detail panel showing full node info, connections, files, commit

**DAG View**
- Hierarchical layout (goals at top, outcomes at bottom)
- Node boxes with unicode borders
- Edge arrows (chosen=bold green, rejected=dashed red)
- Pan with h/j/k/l
- Zoom with +/-

### Key Features

- **Auto-refresh**: Uses `notify` crate to watch database file for changes - no polling needed
- **Code jumping**: `o` key opens associated files in $EDITOR (with multi-select picker for multiple files)
- **Type consistency**: New `src/tui/types.rs` mirrors `web/src/types/graph.ts` for consistent behavior

### New Dependencies

- `ratatui = "0.29"` - Terminal UI framework
- `crossterm = "0.28"` - Terminal event handling
- `tui-tree-widget = "0.22"` - Tree display component
- `notify = "6.1"` - File system watcher for auto-refresh

### Files Changed

| File | Purpose |
|------|---------|
| `src/tui/mod.rs` | Main entry point, event loop |
| `src/tui/app.rs` | Application state management |
| `src/tui/events.rs` | Vim-style keybind handling |
| `src/tui/types.rs` | Type definitions (15 tests) |
| `src/tui/ui.rs` | Layout orchestration |
| `src/tui/views/timeline.rs` | Timeline view |
| `src/tui/views/dag.rs` | DAG visualization |
| `src/tui/views/detail.rs` | Node detail panel |
| `src/tui/widgets/file_picker.rs` | Multi-select file picker |

### Keybindings

**Timeline View**
| Key | Action |
|-----|--------|
| `j/k` | Move up/down |
| `gg` | Jump to top |
| `G` | Jump to bottom |
| `Ctrl+d/u` | Page down/up |
| `/` | Search |
| `f` | Cycle type filter |
| `Enter` | Toggle detail panel |
| `o` | Open associated files |
| `O` | Open commit in git |
| `r` | Manual refresh |
| `Tab` | Switch to DAG view |
| `?` | Help |
| `q` | Quit |

**DAG View**
| Key | Action |
|-----|--------|
| `h/j/k/l` | Pan view |
| `+/-` | Zoom in/out |
| `0` | Reset zoom |
| `Tab` | Switch to Timeline |

## Test Plan

- [ ] Run `cargo test` - 23 tests pass (15 new TUI type tests)
- [ ] Run `cargo build --release`
- [ ] Launch TUI: `./target/release/deciduous tui`
- [ ] Test vim navigation (j/k/gg/G)
- [ ] Test search with `/`
- [ ] Test type filter with `f`
- [ ] Test Tab to switch to DAG view
- [ ] Test zoom (+/-) and pan (h/j/k/l) in DAG
- [ ] Test help overlay with `?`
- [ ] Test quit with `q`
- [ ] Verify auto-refresh works when adding a node in another terminal