### PR TITLE
feat: add --commit HEAD auto-detection for commit linking

### DIFF
--- a/.claude/commands/decision.md
+++ b/.claude/commands/decision.md
@@ -43,7 +43,17 @@ Based on $ARGUMENTS:
 - `-f, --files "file1.rs,file2.rs"` - Associate files with this node
 - `-b, --branch <name>` - Git branch (auto-detected by default)
 - `--no-branch` - Skip branch auto-detection
-- `--commit <hash>` - Link to a git commit
+- `--commit <hash|HEAD>` - Link to a git commit (use HEAD for current commit)
+
+### ⚠️ CRITICAL: Link Commits to Actions/Outcomes
+
+**After every git commit, link it to the decision graph!**
+
+```bash
+git commit -m "feat: add auth"
+deciduous add action "Implemented auth" -c 90 --commit HEAD
+deciduous link <goal_id> <action_id> -r "Implementation"
+```
 
 ## CRITICAL: Capture User Prompts When Semantically Meaningful
 

--- a/.windsurf/rules/deciduous.md
+++ b/.windsurf/rules/deciduous.md
@@ -71,10 +71,15 @@ deciduous add observation "Title" -c 80
 # -f, --files "a.rs,b.rs"   Associate files with this node
 # -b, --branch <name>   Git branch (auto-detected by default)
 # --no-branch   Skip branch auto-detection
-# --commit <hash>   Link to a git commit
+# --commit <hash|HEAD>   Link to a git commit (use HEAD for current commit)
 
 # Example with prompt and files on root goal
 deciduous add goal "Add auth" -c 90 -p "User asked: add login feature" -f "src/auth.rs,src/routes.rs"
+
+# CRITICAL: After git commits, link them to the graph!
+git commit -m "feat: add auth"
+deciduous add action "Implemented auth" -c 90 --commit HEAD   # Auto-detects current commit
+deciduous link <goal_id> <action_id> -r "Implementation"
 
 # Filter by branch
 deciduous nodes --branch main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,22 @@ deciduous graph           # Full graph as JSON
 deciduous sync            # Export to .deciduous/web/graph-data.json
 ```
 
+### ⚠️ CRITICAL: Link Commits to Actions/Outcomes
+
+**After every git commit, link it to the decision graph using `--commit HEAD`!**
+
+```bash
+# AFTER committing code, log the action/outcome with --commit HEAD
+git commit -m "feat: add auth"
+deciduous add action "Implemented auth feature" -c 90 --commit HEAD
+deciduous link <goal_id> <action_id> -r "Implementation"
+
+# For completed features, log the outcome
+deciduous add outcome "Auth feature merged" -c 95 --commit HEAD
+```
+
+The `--commit HEAD` flag auto-detects the current commit hash. This creates traceability between commits and decisions, visible in both TUI and web viewer.
+
 ### Confidence Levels
 
 - **90-100**: Certain, proven, tested

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,15 +72,33 @@ deciduous link FROM TO -r "reason"  # DO THIS IMMEDIATELY!
 deciduous serve   # View live (auto-refreshes every 30s)
 deciduous sync    # Export for static hosting
 
-# Optional metadata
-# -p, --prompt "..."   Store the user prompt (use when semantically meaningful)
-# -f, --files "a.rs,b.rs"   Associate files
-# -b, --branch <name>   Git branch (auto-detected)
+# Metadata flags
+# -c, --confidence 0-100   Confidence level
+# -p, --prompt "..."       Store the user prompt (use when semantically meaningful)
+# -f, --files "a.rs,b.rs"  Associate files
+# -b, --branch <name>      Git branch (auto-detected)
+# --commit <hash|HEAD>     Link to git commit (use HEAD for current commit)
 
 # Branch filtering
 deciduous nodes --branch main
 deciduous nodes -b feature-auth
 ```
+
+### ⚠️ CRITICAL: Link Commits to Actions/Outcomes
+
+**After every git commit, link it to the decision graph!**
+
+```bash
+# AFTER committing code, log an action/outcome with --commit HEAD
+git commit -m "feat: add auth"
+deciduous add action "Implemented auth feature" -c 90 --commit HEAD
+deciduous link <goal_id> <action_id> -r "Implementation"
+
+# Or log the outcome of a completed feature
+deciduous add outcome "Auth feature merged" -c 95 --commit HEAD
+```
+
+This creates traceability between commits and decisions. The TUI and web viewer show commits linked to nodes.
 
 ### Branch-Based Grouping
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -65,6 +65,24 @@ pub fn get_current_git_branch() -> Option<String> {
         })
 }
 
+/// Get the current HEAD commit hash (short form, 7 chars)
+pub fn get_current_git_commit() -> Option<String> {
+    std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                String::from_utf8(output.stdout)
+                    .ok()
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+            } else {
+                None
+            }
+        })
+}
+
 /// Walk up directory tree to find .deciduous folder (like git finds .git)
 /// Can be overridden with DECIDUOUS_DB_PATH env var
 fn get_db_path() -> std::path::PathBuf {

--- a/src/init.rs
+++ b/src/init.rs
@@ -107,7 +107,17 @@ Based on $ARGUMENTS:
 - `-f, --files "file1.rs,file2.rs"` - Associate files with this node
 - `-b, --branch <name>` - Git branch (auto-detected by default)
 - `--no-branch` - Skip branch auto-detection
-- `--commit <hash>` - Link to a git commit
+- `--commit <hash|HEAD>` - Link to a git commit (use HEAD for current commit)
+
+### ⚠️ CRITICAL: Link Commits to Actions/Outcomes
+
+**After every git commit, link it to the decision graph!**
+
+```bash
+git commit -m "feat: add auth"
+deciduous add action "Implemented auth" -c 90 --commit HEAD
+deciduous link <goal_id> <action_id> -r "Implementation"
+```
 
 ## CRITICAL: Capture User Prompts When Semantically Meaningful
 
@@ -657,14 +667,26 @@ deciduous link FROM TO -r "reason"  # DO THIS IMMEDIATELY!
 deciduous serve   # View live (auto-refreshes every 30s)
 deciduous sync    # Export for static hosting
 
-# Optional metadata
-# -p, --prompt "..."   Store the user prompt (use when semantically meaningful)
-# -f, --files "a.rs,b.rs"   Associate files
-# -b, --branch <name>   Git branch (auto-detected)
+# Metadata flags
+# -c, --confidence 0-100   Confidence level
+# -p, --prompt "..."       Store the user prompt (use when semantically meaningful)
+# -f, --files "a.rs,b.rs"  Associate files
+# -b, --branch <name>      Git branch (auto-detected)
+# --commit <hash|HEAD>     Link to git commit (use HEAD for current commit)
 
 # Branch filtering
 deciduous nodes --branch main
 deciduous nodes -b feature-auth
+```
+
+### ⚠️ CRITICAL: Link Commits to Actions/Outcomes
+
+**After every git commit, link it to the decision graph!**
+
+```bash
+git commit -m "feat: add auth"
+deciduous add action "Implemented auth" -c 90 --commit HEAD
+deciduous link <goal_id> <action_id> -r "Implementation"
 ```
 
 ### Branch-Based Grouping
@@ -787,10 +809,15 @@ deciduous add observation "Title" -c 80
 # -p, --prompt "..."   Store the user prompt that triggered this
 # -f, --files "a.rs,b.rs"   Associate files with this node
 # -b, --branch <name>   Git branch (auto-detected)
-# --commit <hash>   Link to a git commit
+# --commit <hash|HEAD>   Link to a git commit (use HEAD for current commit)
 
 # Example with prompt and files
 deciduous add goal "Add auth" -c 90 -p "User asked: add login feature" -f "src/auth.rs,src/routes.rs"
+
+# CRITICAL: After git commits, link them to the graph!
+git commit -m "feat: add auth"
+deciduous add action "Implemented auth" -c 90 --commit HEAD   # Auto-detects current commit
+deciduous link <goal_id> <action_id> -r "Implementation"
 
 # Filter by branch
 deciduous nodes --branch main

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub mod tui;
 pub use config::Config;
 pub use db::{
     CommandLog, Database, DbRecord, DbSummary, DecisionEdge, DecisionGraph, DecisionNode,
-    CURRENT_SCHEMA, get_current_git_branch, build_metadata_json,
+    CURRENT_SCHEMA, get_current_git_branch, get_current_git_commit, build_metadata_json,
 };
 pub use diff::{GraphPatch, PatchNode, PatchEdge, ApplyResult};
 pub use export::{graph_to_dot, generate_pr_writeup, filter_graph_from_roots, filter_graph_by_ids, parse_node_range, DotConfig, WriteupConfig};


### PR DESCRIPTION
## Summary

Adds automatic commit linking to the decision graph. Users can now use `--commit HEAD` to auto-detect and link the current commit hash when creating nodes.

**Root Cause**: The `--commit` flag existed but was undocumented and required manual hash entry. This made it impractical to use, so commits were never linked to decision nodes.

## Changes

### Code
- **src/db.rs**: Added `get_current_git_commit()` function to get short HEAD hash
- **src/lib.rs**: Export the new function
- **src/main.rs**: Expand "HEAD" keyword to actual commit hash in `add` command

### Documentation (all updated with commit linking guidance)
- **CLAUDE.md**: Added "CRITICAL: Link Commits to Actions/Outcomes" section
- **AGENTS.md**: Added commit linking section with examples
- **.claude/commands/decision.md**: Updated flags, added commit examples
- **.windsurf/rules/deciduous.md**: Updated flags, added commit examples
- **src/init.rs**: Updated all templates with commit linking

## Usage

```bash
# After a git commit, link it to the decision graph
git commit -m "feat: add auth"
deciduous add action "Implemented auth" -c 90 --commit HEAD
deciduous link <goal_id> <action_id> -r "Implementation"
```

The `--commit HEAD` flag auto-detects the current commit hash (e.g., `f6d250b`) and stores it in node metadata, creating traceability between commits and decision graph nodes.

## Test Plan

- [x] `cargo test` passes
- [x] `cargo build --release` succeeds
- [x] Manual test: `deciduous add action "Test" --commit HEAD` correctly expands to commit hash
- [ ] Verify documentation renders correctly in editors