### PR TITLE
feat: add deciduous import command to extract decisions from Claude s…

### DIFF
--- a/.claude/commands/import-session.md
+++ b/.claude/commands/import-session.md
@@ -1,0 +1,16 @@
+In a subagent, analyze the Claude Code session transcript at: $ARGUMENTS
+
+Read the JSONL file and extract all implicit decisions, goals, actions, and outcomes. For each one:
+
+1. Identify the node type (goal, decision, action, outcome, observation)
+2. Determine an appropriate title
+3. Estimate a confidence score (0-100)
+4. Identify relationships between nodes
+
+Then execute the appropriate deciduous commands:
+- `deciduous add <type> "title" -c <confidence>`
+- `deciduous link <from> <to> -r "reason"`
+
+Start with root goals (user requests), then work through decisions and actions that flowed from them.
+
+Focus on substantive decisions, not routine operations. A "decision" is a choice between alternatives. An "action" is implementation work. An "outcome" is a result.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "colored",
  "crossterm",
  "diesel",
+ "dirs",
  "lazy_static",
  "libsqlite3-sys",
  "notify",
@@ -461,6 +462,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe2444076b48641147115697648dc743c2c00b61adade0f01ce67133c7babe8c"
 dependencies = [
  "syn",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -579,6 +601,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -942,6 +975,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,6 +1139,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1288,7 +1338,7 @@ checksum = "60bdd87fcb4c9764b024805fb2df5f1d659bea6e629fdbdcdcfc4042b9a640d0"
 dependencies = [
  "js-sys",
  "once_cell",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1357,7 +1407,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.17",
  "walkdir",
  "yaml-rust",
 ]
@@ -1375,11 +1425,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.17",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1545,7 +1615,7 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,9 @@ syntect = { version = "5.2", default-features = false, features = ["default-fanc
 syntect-tui = "3.0"
 lazy_static = "1.4"
 
+# Cross-platform paths
+dirs = "5.0"
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,0 +1,177 @@
+//! Import decisions from Claude Code session files
+//!
+//! Claude Code stores session transcripts as JSONL files in ~/.claude/projects/.
+//! This module discovers those files and invokes Claude to extract decisions.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Get the Claude projects directory for the current platform
+pub fn claude_projects_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".claude").join("projects"))
+}
+
+/// Convert a working directory path to Claude's project folder name format
+/// e.g., "C:\Users\Nat\source\deciduous" -> "C--Users-Nat-source-deciduous"
+/// e.g., "/home/user/project" -> "-home-user-project"
+pub fn path_to_project_name(path: &std::path::Path) -> String {
+    let path_str = path.to_string_lossy();
+
+    // Replace path separators and colons with dashes
+    path_str
+        .replace('\\', "-")
+        .replace('/', "-")
+        .replace(':', "-")
+}
+
+/// Find Claude session files for a given project directory
+pub fn find_session_files(project_path: &std::path::Path) -> Result<Vec<SessionFile>, String> {
+    let projects_dir = claude_projects_dir()
+        .ok_or_else(|| "Could not determine home directory".to_string())?;
+
+    let project_name = path_to_project_name(project_path);
+    let project_sessions_dir = projects_dir.join(&project_name);
+
+    if !project_sessions_dir.exists() {
+        return Err(format!(
+            "No Claude sessions found for this project.\nExpected: {}\nProject name: {}",
+            project_sessions_dir.display(),
+            project_name
+        ));
+    }
+
+    let mut sessions = Vec::new();
+
+    let entries = std::fs::read_dir(&project_sessions_dir)
+        .map_err(|e| format!("Failed to read sessions directory: {}", e))?;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().map(|e| e == "jsonl").unwrap_or(false) {
+            // Skip agent files (subagent sessions) - focus on main sessions
+            let filename = path.file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("");
+
+            if filename.starts_with("agent-") {
+                continue;
+            }
+
+            // Get file metadata for sorting
+            let metadata = std::fs::metadata(&path).ok();
+            let modified = metadata.as_ref().and_then(|m| m.modified().ok());
+            let size = metadata.map(|m| m.len()).unwrap_or(0);
+
+            sessions.push(SessionFile {
+                path,
+                modified,
+                size,
+            });
+        }
+    }
+
+    // Sort by modification time, newest first
+    sessions.sort_by(|a, b| b.modified.cmp(&a.modified));
+
+    Ok(sessions)
+}
+
+/// A Claude Code session file
+#[derive(Debug)]
+pub struct SessionFile {
+    pub path: PathBuf,
+    pub modified: Option<std::time::SystemTime>,
+    pub size: u64,
+}
+
+impl SessionFile {
+    /// Format the modification time as a human-readable string
+    pub fn modified_str(&self) -> String {
+        self.modified
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| {
+                let secs = d.as_secs();
+                let dt = chrono::DateTime::from_timestamp(secs as i64, 0)
+                    .unwrap_or_default();
+                dt.format("%Y-%m-%d %H:%M").to_string()
+            })
+            .unwrap_or_else(|| "unknown".to_string())
+    }
+
+    /// Get the session ID (filename without extension)
+    pub fn session_id(&self) -> String {
+        self.path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string()
+    }
+}
+
+/// Import decisions from a session file by invoking Claude
+pub fn import_session(session_path: &std::path::Path, dry_run: bool) -> Result<(), String> {
+    if !session_path.exists() {
+        return Err(format!("Session file not found: {}", session_path.display()));
+    }
+
+    // Build the prompt for Claude
+    let prompt = format!(
+        r#"Analyze the Claude Code session transcript at: {}
+
+Read the JSONL file and extract all implicit decisions, goals, actions, and outcomes. For each one:
+
+1. Identify the node type (goal, decision, action, outcome, observation)
+2. Determine an appropriate title
+3. Estimate a confidence score (0-100)
+4. Identify relationships between nodes
+
+Then execute the appropriate deciduous commands:
+- `deciduous add <type> "title" -c <confidence>`
+- `deciduous link <from> <to> -r "reason"`
+
+Start with root goals (user requests), then work through decisions and actions that flowed from them.
+
+Focus on substantive decisions, not routine operations. A "decision" is a choice between alternatives. An "action" is implementation work. An "outcome" is a result."#,
+        session_path.display()
+    );
+
+    if dry_run {
+        println!("Would run claude with prompt:");
+        println!("---");
+        println!("{}", prompt);
+        println!("---");
+        return Ok(());
+    }
+
+    // Invoke claude CLI
+    let status = Command::new("claude")
+        .arg("-p")
+        .arg(&prompt)
+        .status()
+        .map_err(|e| format!("Failed to run claude: {}\nIs claude CLI installed and in PATH?", e))?;
+
+    if !status.success() {
+        return Err(format!("Claude exited with status: {}", status));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_path_to_project_name_windows() {
+        let path = std::path::Path::new("C:\\Users\\Nat\\source\\deciduous");
+        let name = path_to_project_name(path);
+        assert_eq!(name, "C--Users-Nat-source-deciduous");
+    }
+
+    #[test]
+    fn test_path_to_project_name_unix() {
+        let path = std::path::Path::new("/home/user/projects/myapp");
+        let name = path_to_project_name(path);
+        assert_eq!(name, "-home-user-projects-myapp");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub mod config;
 pub mod db;
 pub mod diff;
 pub mod export;
+pub mod import;
 pub mod init;
 pub mod schema;
 pub mod serve;


### PR DESCRIPTION
…essions

- Discovers Claude Code session files at ~/.claude/projects/<project>/
- Cross-platform support (Windows, macOS, Linux) via dirs crate
- Lists sessions with --list flag showing date and size
- Imports by invoking claude CLI with extraction prompt
- Supports --session ID, --all, and --dry-run flags
- Also adds /import-session slash command for interactive use

The "tests" are stupid, but I don't know what you'd prefer in their place.