### PR TITLE
fix: sync command writes to docs/demo/ for GitHub Pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "deciduous"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deciduous"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Trey Anastasio <trey@example.com>"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -515,10 +515,18 @@ fn main() {
                 Ok(graph) => {
                     match serde_json::to_string_pretty(&graph) {
                         Ok(json) => {
-                            match std::fs::write(&output_path, json) {
+                            match std::fs::write(&output_path, &json) {
                                 Ok(()) => {
                                     println!("{} graph to {}", "Exported".green(), output_path.display());
                                     println!("  {} nodes, {} edges", graph.nodes.len(), graph.edges.len());
+
+                                    // Also sync to docs/demo/ if it exists (for GitHub Pages demo)
+                                    let demo_path = PathBuf::from("docs/demo/graph-data.json");
+                                    if demo_path.parent().map(|p| p.exists()).unwrap_or(false) {
+                                        if let Err(e) = std::fs::write(&demo_path, &json) {
+                                            eprintln!("{} Also writing to demo/: {}", "Warning:".yellow(), e);
+                                        }
+                                    }
                                 }
                                 Err(e) => {
                                     eprintln!("{} Writing file: {}", "Error:".red(), e);


### PR DESCRIPTION
## Summary
- `deciduous sync` now also copies graph-data.json to `docs/demo/` if that directory exists
- Fixes issue where the GitHub Pages demo was showing stale data (107 nodes instead of 349)
- Bumps version to 0.8.4

## Test plan
- [x] `cargo test` passes
- [x] `cargo build --release` succeeds
- [ ] After merge, verify `deciduous sync` writes to both locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)