### PR TITLE
feat(roadmap): Phase 3-5 - GitHub CLI integration and sync commands

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub mod tui;
 pub use config::Config;
 pub use db::{
     CommandLog, Database, DbRecord, DbSummary, DecisionEdge, DecisionGraph, DecisionNode,
-    DecisionContext, DecisionSession, CheckboxState, RoadmapItem,
+    DecisionContext, DecisionSession, CheckboxState, RoadmapItem, GitHubIssueCache,
     CURRENT_SCHEMA, get_current_git_branch, get_current_git_commit, build_metadata_json,
 };
 pub use diff::{GraphPatch, PatchNode, PatchEdge, ApplyResult};

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -133,3 +133,22 @@ diesel::table! {
         resolved_at -> Nullable<Text>,
     }
 }
+
+// ============================================================================
+// GitHub Issue Cache - Local cache for TUI/Web display
+// ============================================================================
+
+diesel::table! {
+    github_issue_cache (id) {
+        id -> Integer,
+        issue_number -> Integer,
+        repo -> Text,
+        title -> Text,
+        body -> Nullable<Text>,
+        state -> Text,
+        html_url -> Text,
+        created_at -> Text,
+        updated_at -> Text,
+        cached_at -> Text,
+    }
+}


### PR DESCRIPTION
# Roadmap Board System - Part 2: GitHub Integration & CLI

## Context

With the data layer in place (PR #87), we can now connect to GitHub. This PR adds:

1. **GitHub CLI wrapper** - Shell out to `gh` for issue operations
2. **Sync engine** - Bidirectional sync between ROADMAP.md and GitHub Issues
3. **CLI commands** - `deciduous roadmap init/sync/list/link`

## Why Shell Out to `gh`?

We use GitHub's official CLI (`gh`) rather than the REST API because:

| Approach | Pros | Cons |
|----------|------|------|
| `gh` CLI | No token management, uses existing auth, handles rate limiting | Requires `gh` installed |
| REST API | No external dependency | Token management, rate limit handling, more code |
| GraphQL API | Efficient batching | Complex, token management |

**Decision**: Shell out to `gh`. Users already have it for `gh pr create`. If they don't, they get a clear error message.

## New Files

### `src/github.rs` (~400 lines)

GitHub CLI wrapper with typed responses:

```rust
pub struct GitHubClient {
    repo: Option<String>,  // "owner/repo" format
}

impl GitHubClient {
    pub fn auto_detect() -> Result<Self>;
    pub fn check_auth() -> Result<bool>;
    
    // Issue operations
    pub fn create_issue(&self, title: &str, body: &str, labels: &[&str]) -> Result<GitHubIssue>;
    pub fn update_issue_body(&self, number: i32, body: &str) -> Result<()>;
    pub fn close_issue(&self, number: i32) -> Result<()>;
    pub fn get_issue(&self, number: i32) -> Result<GitHubIssue>;
    
    // Label operations (NEW)
    pub fn label_exists(&self, name: &str) -> Result<bool>;
    pub fn create_label(&self, name: &str, description: &str, color: &str) -> Result<()>;
}

// Auto-create roadmap label if needed
pub fn ensure_roadmap_label(client: &GitHubClient) -> Result<bool>;
```

### CLI Commands

```bash
# Initialize roadmap tracking
deciduous roadmap init [--path ROADMAP.md]

# Sync with GitHub (dry-run by default!)
deciduous roadmap sync [--execute] [--path PATH] [--repo OWNER/REPO]

# List items
deciduous roadmap list [--with-issues] [--without-issues] [--section NAME]

# Link to outcome
deciduous roadmap link ITEM OUTCOME_ID
```

## Feedback Discussion Summary

| Question | Answer | Implementation |
|----------|--------|----------------|
| Cache GitHub state locally? | **Yes** - for TUI + serve + web | ✅ Added `github_issue_cache` table |
| Rate limits? | OK as-is, one-time | No changes needed |
| `roadmap init` idempotent? | Yes, but separate patch | Will be separate PR |
| `--dry-run` default? | **Yes** | ✅ Requires `--execute` to apply |
| Auto-create "roadmap" label? | **Yes** | ✅ Auto-creates on first sync |

## New: GitHub Issue Cache

For TUI/Web display without hitting GitHub's API:

```sql
CREATE TABLE github_issue_cache (
    id INTEGER PRIMARY KEY,
    issue_number INTEGER NOT NULL,
    repo TEXT NOT NULL,
    title TEXT NOT NULL,
    body TEXT,
    state TEXT NOT NULL,
    html_url TEXT NOT NULL,
    created_at TEXT NOT NULL,
    updated_at TEXT NOT NULL,
    cached_at TEXT NOT NULL,
    UNIQUE(repo, issue_number)
);
```

**Methods:**
- `db.cache_github_issue(...)` - Cache/update an issue
- `db.get_cached_issue(repo, number)` - Get cached issue
- `db.get_cached_issues_for_repo(repo)` - All issues for a repo
- `db.clear_stale_cache(max_age_hours)` - Cleanup old entries

## Sync Architecture

```
                    ┌─────────────────┐
                    │   ROADMAP.md    │
                    │  (human edits)  │
                    └────────┬────────┘
                             │ parse
                             ▼
                    ┌─────────────────┐
                    │     SQLite      │────┐
                    │ (roadmap_items) │    │
                    └────────┬────────┘    │
                             │ sync        │ cache
                             ▼             ▼
                    ┌─────────────────┐ ┌───────────────┐
                    │  GitHub Issues  │ │ Issue Cache   │
                    │ (team visible)  │ │ (TUI/Web)     │
                    └─────────────────┘ └───────────────┘
```

**Default is safe**: `roadmap sync` shows what would happen without making changes. Use `--execute` to actually create issues.

## Decision Graph References

| Node | Type | Description |
|------|------|-------------|
| #477 | decision | "Choose sync architecture" |
| #478 | option | "Bidirectional sync" ← CHOSEN |
| #497 | action | "Implementing Phase 3: GitHub CLI" |
| #498 | outcome | "Phase 3 complete: GitHub CLI integration" |
| #499 | action | "Implementing Phase 4-5: CLI + Sync" |
| #500 | outcome | "Phase 4-5 complete: CLI commands with sync" |

## Test Plan

- [x] `cargo build` - Compiles
- [x] `cargo test` - Tests pass
- [ ] Manual: `gh auth status` shows authenticated
- [ ] Manual: `roadmap init` parses ROADMAP.md
- [ ] Manual: `roadmap sync` (dry-run default) shows what would happen
- [ ] Manual: `roadmap sync --execute` creates issues
- [ ] Manual: Verify 'roadmap' label auto-created
- [ ] Manual: `roadmap list --with-issues` shows linked items

## Merge Dependencies

**Requires PR #87** (Data Layer) to be merged first.

## Next PR

**Part 3: TUI View** will add:
- `src/tui/views/roadmap.rs` - Terminal roadmap browser
- Display cached issues without network calls