### PR TITLE
fix(tui): roadmap 'o' keystroke now opens correct GitHub repo

### DIFF
--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -357,7 +357,9 @@ fn handle_roadmap_keys(app: &mut App, key: KeyEvent) -> bool {
 
         // Open GitHub issue in browser
         KeyCode::Char('o') => {
-            if let Some(url) = app.roadmap_state.selected_issue_url() {
+            if app.roadmap_state.github_repo.is_none() {
+                app.set_status("No GitHub repo configured. Set up roadmap sync or add git remote.".to_string());
+            } else if let Some(url) = app.roadmap_state.selected_issue_url() {
                 // Open URL in default browser
                 #[cfg(target_os = "macos")]
                 let result = std::process::Command::new("open").arg(&url).spawn();

--- a/src/tui/msg.rs
+++ b/src/tui/msg.rs
@@ -336,4 +336,73 @@ mod tests {
         assert!(is_filter_change(&Msg::CycleBranchFilter));
         assert!(!is_filter_change(&Msg::MoveUp));
     }
+
+    #[test]
+    fn test_key_to_msg_actions() {
+        // Test action keys - these trigger side effects
+        assert_eq!(key_to_msg(KeyCode::Char('o'), KeyModifiers::NONE, false, false), Msg::OpenFiles);
+        assert_eq!(key_to_msg(KeyCode::Char('r'), KeyModifiers::NONE, false, false), Msg::RefreshGraph);
+        assert_eq!(key_to_msg(KeyCode::Char('y'), KeyModifiers::NONE, false, false), Msg::CopyToClipboard);
+    }
+
+    #[test]
+    fn test_key_to_msg_view_switching() {
+        assert_eq!(key_to_msg(KeyCode::Tab, KeyModifiers::NONE, false, false), Msg::NextView);
+        assert_eq!(key_to_msg(KeyCode::Tab, KeyModifiers::SHIFT, false, false), Msg::PrevView);
+        assert_eq!(key_to_msg(KeyCode::Char('1'), KeyModifiers::NONE, false, false), Msg::SwitchToView(ViewKind::Timeline));
+        assert_eq!(key_to_msg(KeyCode::Char('2'), KeyModifiers::NONE, false, false), Msg::SwitchToView(ViewKind::Dag));
+        assert_eq!(key_to_msg(KeyCode::Char('3'), KeyModifiers::NONE, false, false), Msg::SwitchToView(ViewKind::Graph));
+    }
+
+    #[test]
+    fn test_key_to_msg_filtering() {
+        assert_eq!(key_to_msg(KeyCode::Char('t'), KeyModifiers::NONE, false, false), Msg::CycleTypeFilter);
+        assert_eq!(key_to_msg(KeyCode::Char('b'), KeyModifiers::NONE, false, false), Msg::CycleBranchFilter);
+        assert_eq!(key_to_msg(KeyCode::Char('B'), KeyModifiers::NONE, false, false), Msg::OpenBranchSearch);
+        assert_eq!(key_to_msg(KeyCode::Char('/'), KeyModifiers::NONE, false, false), Msg::OpenBranchSearch);
+    }
+
+    #[test]
+    fn test_key_to_msg_modals() {
+        assert_eq!(key_to_msg(KeyCode::Char('?'), KeyModifiers::NONE, false, false), Msg::ToggleHelp);
+        assert_eq!(key_to_msg(KeyCode::Char('P'), KeyModifiers::NONE, false, false), Msg::OpenPromptModal);
+        assert_eq!(key_to_msg(KeyCode::Esc, KeyModifiers::NONE, false, false), Msg::CloseModal);
+    }
+
+    #[test]
+    fn test_key_to_msg_file_browser() {
+        assert_eq!(key_to_msg(KeyCode::Char('F'), KeyModifiers::NONE, false, false), Msg::ToggleFileBrowser);
+        assert_eq!(key_to_msg(KeyCode::Char('p'), KeyModifiers::NONE, false, false), Msg::PreviewFile);
+    }
+
+    #[test]
+    fn test_key_to_msg_detail_panel() {
+        assert_eq!(key_to_msg(KeyCode::Enter, KeyModifiers::NONE, false, false), Msg::ToggleDetailPanel);
+        assert_eq!(key_to_msg(KeyCode::Char('l'), KeyModifiers::NONE, false, false), Msg::DetailScrollDown);
+        assert_eq!(key_to_msg(KeyCode::Char('h'), KeyModifiers::NONE, false, false), Msg::DetailScrollUp);
+    }
+
+    #[test]
+    fn test_key_to_msg_page_navigation() {
+        assert_eq!(key_to_msg(KeyCode::Char('d'), KeyModifiers::CONTROL, false, false), Msg::PageDown);
+        assert_eq!(key_to_msg(KeyCode::Char('u'), KeyModifiers::CONTROL, false, false), Msg::PageUp);
+        assert_eq!(key_to_msg(KeyCode::PageDown, KeyModifiers::NONE, false, false), Msg::PageDown);
+        assert_eq!(key_to_msg(KeyCode::PageUp, KeyModifiers::NONE, false, false), Msg::PageUp);
+        assert_eq!(key_to_msg(KeyCode::Char('g'), KeyModifiers::NONE, false, false), Msg::JumpToTop);
+        assert_eq!(key_to_msg(KeyCode::Char('G'), KeyModifiers::NONE, false, false), Msg::JumpToBottom);
+        assert_eq!(key_to_msg(KeyCode::Home, KeyModifiers::NONE, false, false), Msg::JumpToTop);
+        assert_eq!(key_to_msg(KeyCode::End, KeyModifiers::NONE, false, false), Msg::JumpToBottom);
+    }
+
+    #[test]
+    fn test_key_to_msg_goal_story() {
+        assert_eq!(key_to_msg(KeyCode::Char('s'), KeyModifiers::NONE, false, false), Msg::ToggleGoalStory);
+    }
+
+    #[test]
+    fn test_key_to_msg_unhandled() {
+        // Keys that aren't mapped should return Noop
+        assert_eq!(key_to_msg(KeyCode::Char('z'), KeyModifiers::NONE, false, false), Msg::Noop);
+        assert_eq!(key_to_msg(KeyCode::Char('x'), KeyModifiers::NONE, false, false), Msg::Noop);
+    }
 }


### PR DESCRIPTION
## Summary

- Fixed the 'o' keystroke in the roadmap TUI view which was broken due to a hardcoded GitHub repo URL
- The keystroke now dynamically detects the correct repo from either the database sync state or git remote
- Added comprehensive keystroke tests to `msg.rs`

## Problem

Pressing 'o' on a roadmap item would always try to open issues from `notactuallytreyanastasio/deciduous` regardless of the user's actual repository. This was caused by a hardcoded URL in `selected_issue_url()`:

```rust
// Before (broken)
format!("https://github.com/notactuallytreyanastasio/deciduous/issues/{}", num)
```

## Solution

1. **Added `github_repo` field to `RoadmapState`** - Stores the repo string (e.g., "owner/repo")

2. **Added `detect_github_repo()` method to `App`** - Tries to get the repo from:
   - First: Database `RoadmapSyncState` (if roadmap sync is configured)
   - Fallback: Parse git remote URL (`git@github.com:owner/repo.git` or `https://github.com/owner/repo.git`)

3. **Fixed `selected_issue_url()`** - Now uses the dynamic repo:
   ```rust
   // After (fixed)
   format!("https://github.com/{}/issues/{}", repo, num)
   ```

4. **Improved error handling** - Shows helpful message when no GitHub repo is configured

## Audit Findings

During investigation, I audited the TUI keystroke architecture and found that the TEA `key_to_msg()` function in `msg.rs` is not actually used by `events.rs`. The event handlers are implemented directly, creating some discrepancies:

| Key | msg.rs (TEA) | events.rs (Actual) |
|-----|--------------|-------------------|
| 't' | CycleTypeFilter | Not used |
| 'f' | Not defined | cycle_type_filter |
| 'y' | CopyToClipboard | Not implemented |
| '1/2/3' | SwitchToView | Not implemented |

This is design debt that could be addressed in a future refactor to unify the TEA architecture.

## Test plan

- [x] All existing tests pass (`cargo test`)
- [x] Build succeeds (`cargo build --release`)
- [x] Added new tests for keystroke mappings in `msg.rs`
- [x] Added test for `selected_issue_url` with/without repo configured
- [ ] Manual test: Run `deciduous tui`, go to Roadmap view, press 'o' on an item with a GitHub issue