### PR TITLE
feat: Add OpenCode slash commands for deciduous workflow

### DIFF
--- a/.deciduous/config.toml
+++ b/.deciduous/config.toml
@@ -1,0 +1,11 @@
+# Deciduous Configuration
+# This file controls branch detection and grouping behavior
+
+[branch]
+# Branches considered "main" - nodes on these branches won't trigger feature-branch grouping
+# When working on feature branches, nodes are automatically tagged with the branch name
+main_branches = ["main", "master"]
+
+# Automatically detect and store git branch when creating nodes
+# Set to false to disable branch tracking entirely
+auto_detect = true

--- a/.github/workflows/cleanup-decision-graphs.yml
+++ b/.github/workflows/cleanup-decision-graphs.yml
@@ -1,0 +1,79 @@
+name: Cleanup Decision Graph PNGs
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    # Only run if PR was merged (not just closed)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Find and remove decision graph PNGs
+        id: find-pngs
+        run: |
+          # Find decision graph PNGs (in docs/ or root)
+          PNGS=$(find . -name "decision-graph*.png" -o -name "deciduous-graph*.png" 2>/dev/null | grep -v node_modules || true)
+
+          if [ -z "$PNGS" ]; then
+            echo "No decision graph PNGs found"
+            echo "found=false" >> $GITHUB_OUTPUT
+          else
+            echo "Found PNGs to clean up:"
+            echo "$PNGS"
+            echo "found=true" >> $GITHUB_OUTPUT
+
+            # Remove the files
+            echo "$PNGS" | xargs rm -f
+
+            # Also remove corresponding .dot files
+            for png in $PNGS; do
+              dot_file="${png%.png}.dot"
+              if [ -f "$dot_file" ]; then
+                rm -f "$dot_file"
+                echo "Also removed: $dot_file"
+              fi
+            done
+          fi
+
+      - name: Create cleanup PR
+        if: steps.find-pngs.outputs.found == 'true'
+        run: |
+          # Check if there are changes to commit
+          if git diff --quiet && git diff --staged --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create branch and commit
+          BRANCH="cleanup/decision-graphs-pr-${{ github.event.pull_request.number }}"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "chore: cleanup decision graph assets from PR #${{ github.event.pull_request.number }}"
+          git push origin "$BRANCH"
+
+          # Create and auto-merge PR
+          gh pr create \
+            --title "chore: cleanup decision graph assets from PR #${{ github.event.pull_request.number }}" \
+            --body "Automated cleanup of decision graph PNG/DOT files that were used in PR #${{ github.event.pull_request.number }}.
+
+          These files served their purpose for PR review and are no longer needed." \
+            --head "$BRANCH" \
+            --base main
+
+          # Auto-merge (requires auto-merge enabled on repo)
+          gh pr merge "$BRANCH" --auto --squash --delete-branch || echo "Auto-merge not enabled, PR created for manual merge"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.opencode/command/build-test.md
+++ b/.opencode/command/build-test.md
@@ -1,0 +1,37 @@
+---
+description: "Build the project and run the test suite"
+---
+
+# Build and Test
+
+Build the project and run the test suite.
+
+## Instructions
+
+1. Run the full build and test cycle:
+   ```bash
+   cargo build --release && cargo test
+   ```
+
+2. If tests fail, analyze the failures and explain:
+   - Which test failed
+   - What it was testing
+   - Likely cause of failure
+   - Suggested fix
+
+3. If all tests pass, report success and any warnings from the build.
+
+4. If the user specifies a specific test pattern, run only those tests:
+   ```bash
+   cargo test <pattern>
+   ```
+
+## Test categories in this project
+- `test_public_exports` - API verification
+- `test_filter_graph` - Graph filtering
+- `test_extract_commit` - Commit extraction from metadata
+- `test_extract_confidence` - Confidence extraction from metadata
+- `test_graph_to_dot` - DOT export
+- `test_generate_writeup` - PR writeup generation
+
+$ARGUMENTS

--- a/.opencode/command/context.md
+++ b/.opencode/command/context.md
@@ -1,0 +1,167 @@
+---
+description: "Recover context from decision graph - USE THIS ON SESSION START. Usage: /context [focus-area]"
+---
+
+# Context Recovery
+
+**RUN THIS AT SESSION START.** The decision graph is your persistent memory.
+
+## Step 1: Query the Graph
+
+```bash
+# See all decisions (look for recent ones and pending status)
+deciduous nodes
+
+# Filter by current branch (useful for feature work)
+deciduous nodes --branch $(git rev-parse --abbrev-ref HEAD)
+
+# See how decisions connect
+deciduous edges
+
+# What commands were recently run?
+deciduous commands
+```
+
+**Branch-scoped context**: If working on a feature branch, filter nodes to see only decisions relevant to this branch.
+
+## Step 1.5: Audit Graph Integrity
+
+**CRITICAL: Check that all nodes are logically connected.**
+
+```bash
+# Find nodes with no incoming edges (potential missing connections)
+deciduous edges | cut -d'>' -f2 | cut -d' ' -f2 | sort -u > /tmp/has_parent.txt
+deciduous nodes | tail -n+3 | awk '{print $1}' | while read id; do
+  grep -q "^$id$" /tmp/has_parent.txt || echo "CHECK: $id"
+done
+```
+
+**Review each flagged node:**
+- Root `goal` nodes are VALID without parents
+- `outcome` nodes MUST link back to their action/goal
+- `action` nodes MUST link to their parent goal/decision
+- `option` nodes MUST link to their parent decision
+
+**Fix missing connections:**
+```bash
+deciduous link <parent_id> <child_id> -r "Retroactive connection - <reason>"
+```
+
+## Step 2: Check Git State
+
+```bash
+git status
+git log --oneline -10
+git diff --stat
+```
+
+## After Gathering Context, Report:
+
+1. **Current branch** and pending changes
+2. **Branch-specific decisions** (filter by branch if on feature branch)
+3. **Recent decisions** (especially pending/active ones)
+4. **Last actions** from git log and command log
+5. **Open questions** or unresolved observations
+6. **Suggested next steps**
+
+---
+
+## REMEMBER: Real-Time Logging Required
+
+After recovering context, you MUST follow the logging workflow:
+
+```
+EVERY USER REQUEST -> Log goal/decision first
+BEFORE CODE CHANGES -> Log action
+AFTER CHANGES -> Log outcome, link nodes
+BEFORE GIT PUSH -> deciduous sync
+```
+
+**The user is watching the graph live.** Log as you go, not after.
+
+### Quick Logging Commands
+
+```bash
+# Root goal with user prompt (capture what the user asked for)
+deciduous add goal "What we're trying to do" -c 90 -p "User asked: <their request>"
+
+deciduous add action "What I'm about to implement" -c 85
+deciduous add outcome "What happened" -c 95
+deciduous link FROM TO -r "Connection reason"
+
+deciduous sync  # Do this frequently!
+```
+
+---
+
+## Focus Areas
+
+If $ARGUMENTS specifies a focus, prioritize context for:
+
+- **auth**: Authentication-related decisions
+- **ui** / **graph**: UI and graph viewer state
+- **cli**: Command-line interface changes
+- **api**: API endpoints and data structures
+
+---
+
+## The Memory Loop
+
+```
+SESSION START
+    |
+Run /context -> See past decisions
+    |
+AUDIT -> Fix any orphan nodes first!
+    |
+DO WORK -> Log BEFORE each action
+    |
+CONNECT -> Link new nodes immediately
+    |
+AFTER CHANGES -> Log outcomes, observations
+    |
+AUDIT AGAIN -> Any new orphans?
+    |
+BEFORE PUSH -> deciduous sync
+    |
+PUSH -> Live graph updates
+    |
+SESSION END -> Final audit
+    |
+(repeat)
+```
+
+---
+
+## Multi-User Sync
+
+If working in a team, check for and apply patches from teammates:
+
+```bash
+# Check for unapplied patches
+deciduous diff status
+
+# Apply all patches (idempotent - safe to run multiple times)
+deciduous diff apply .deciduous/patches/*.json
+
+# Preview before applying
+deciduous diff apply --dry-run .deciduous/patches/teammate-feature.json
+```
+
+Before pushing your branch, export your decisions for teammates:
+
+```bash
+# Export your branch's decisions as a patch
+deciduous diff export --branch $(git rev-parse --abbrev-ref HEAD) \
+  -o .deciduous/patches/$(whoami)-$(git rev-parse --abbrev-ref HEAD).json
+
+# Commit the patch file
+git add .deciduous/patches/
+```
+
+## Why This Matters
+
+- Context loss during compaction loses your reasoning
+- The graph survives - query it early, query it often
+- Retroactive logging misses details - log in the moment
+- The user sees the graph live - show your work

--- a/.opencode/command/decision.md
+++ b/.opencode/command/decision.md
@@ -1,0 +1,129 @@
+---
+description: "Manage decision graph - track choices and reasoning. Usage: /decision <action> [args...]"
+---
+
+# Decision Graph Management
+
+**Log decisions IN REAL-TIME as you work, not retroactively.**
+
+## When to Use This
+
+| You're doing this... | Log this type | Command |
+|---------------------|---------------|---------|
+| Starting a new feature | `goal` **with -p** | `/decision add goal "Add user auth" -p "user request"` |
+| Choosing between approaches | `decision` | `/decision add decision "Choose auth method"` |
+| Considering an option | `option` | `/decision add option "JWT tokens"` |
+| About to write code | `action` | `/decision add action "Implementing JWT"` |
+| Noticing something | `observation` | `/decision add obs "Found existing auth code"` |
+| Finished something | `outcome` | `/decision add outcome "JWT working"` |
+
+## Quick Commands
+
+Based on $ARGUMENTS:
+
+### View Commands
+- `nodes` or `list` -> `deciduous nodes`
+- `edges` -> `deciduous edges`
+- `graph` -> `deciduous graph`
+- `commands` -> `deciduous commands`
+
+### Create Nodes (with optional metadata)
+- `add goal <title>` -> `deciduous add goal "<title>" -c 90`
+- `add decision <title>` -> `deciduous add decision "<title>" -c 75`
+- `add option <title>` -> `deciduous add option "<title>" -c 70`
+- `add action <title>` -> `deciduous add action "<title>" -c 85`
+- `add obs <title>` -> `deciduous add observation "<title>" -c 80`
+- `add outcome <title>` -> `deciduous add outcome "<title>" -c 90`
+
+### Optional Flags for Nodes
+- `-c, --confidence <0-100>` - Confidence level
+- `-p, --prompt "..."` - Store the user prompt that triggered this node
+- `-f, --files "file1.rs,file2.rs"` - Associate files with this node
+- `-b, --branch <name>` - Git branch (auto-detected by default)
+- `--no-branch` - Skip branch auto-detection
+- `--commit <hash|HEAD>` - Link to a git commit (use HEAD for current commit)
+
+### CRITICAL: Link Commits to Actions/Outcomes
+
+**After every git commit, link it to the decision graph!**
+
+```bash
+git commit -m "feat: add auth"
+deciduous add action "Implemented auth" -c 90 --commit HEAD
+deciduous link <goal_id> <action_id> -r "Implementation"
+```
+
+## CRITICAL: Capture User Prompts When Semantically Meaningful
+
+**Use `-p` / `--prompt` when a user request triggers new work or changes direction.** Don't add prompts to every node - only when a prompt is the actual catalyst.
+
+```bash
+# New feature request - capture the prompt on the goal
+deciduous add goal "Add auth" -c 90 -p "User asked: add login to the app"
+
+# Downstream work links back - no prompt needed (it flows via edges)
+deciduous add decision "Choose auth method" -c 75
+deciduous link <goal_id> <decision_id> -r "Deciding approach"
+
+# BUT if the user gives new direction mid-stream, capture that too
+deciduous add action "Switch to OAuth" -c 85 -p "User said: use OAuth instead"
+```
+
+**When to capture prompts:**
+- Root `goal` nodes: YES - the original request
+- Major direction changes: YES - when user redirects the work
+- Routine downstream nodes: NO - they inherit context via edges
+
+### Create Edges
+- `link <from> <to> [reason]` -> `deciduous link <from> <to> -r "<reason>"`
+
+### Sync Graph
+- `sync` -> `deciduous sync`
+
+### Multi-User Sync (Diff/Patch)
+- `diff export -o <file>` -> `deciduous diff export -o <file>`
+- `diff export --nodes 1-10 -o <file>` -> export specific nodes
+- `diff export --branch feature-x -o <file>` -> export nodes from branch
+- `diff apply <file>` -> `deciduous diff apply <file>` (idempotent)
+- `diff apply --dry-run <file>` -> preview without applying
+- `diff status` -> `deciduous diff status`
+
+### Export & Visualization
+- `dot` -> `deciduous dot`
+- `dot --png` -> `deciduous dot --png -o graph.dot`
+- `writeup` -> `deciduous writeup`
+- `writeup -t "Title" --nodes 1-11` -> filtered writeup
+
+## Node Types
+
+| Type | Purpose | Example |
+|------|---------|---------|
+| `goal` | High-level objective | "Add user authentication" |
+| `decision` | Choice point with options | "Choose auth method" |
+| `option` | Possible approach | "Use JWT tokens" |
+| `action` | Something implemented | "Added JWT middleware" |
+| `outcome` | Result of action | "JWT auth working" |
+| `observation` | Finding or data point | "Existing code uses sessions" |
+
+## Graph Integrity - CRITICAL
+
+**Every node MUST be logically connected.** Floating nodes break the graph's value.
+
+### Connection Rules
+| Node Type | MUST connect to |
+|-----------|----------------|
+| `outcome` | The action/goal it resolves |
+| `action` | The decision/goal that spawned it |
+| `option` | Its parent decision |
+| `observation` | Related goal/action/decision |
+| `decision` | Parent goal (if any) |
+| `goal` | Can be a root (no parent needed) |
+
+## The Rule
+
+```
+LOG BEFORE YOU CODE, NOT AFTER.
+CONNECT EVERY NODE TO ITS PARENT.
+AUDIT FOR ORPHANS REGULARLY.
+SYNC BEFORE YOU PUSH.
+```

--- a/.opencode/command/serve-ui.md
+++ b/.opencode/command/serve-ui.md
@@ -1,0 +1,43 @@
+---
+description: "Launch the deciduous web server for viewing the decision graph"
+---
+
+# Start Decision Graph Viewer
+
+Launch the deciduous web server for viewing and navigating the decision graph.
+
+## Instructions
+
+1. Start the server:
+   ```bash
+   deciduous serve --port 3000
+   ```
+
+2. Inform the user:
+   - The server is running at http://localhost:3000
+   - The graph auto-refreshes every 30 seconds
+   - They can browse decisions, chains, and timeline views
+   - Changes made via CLI will appear automatically
+
+3. The server will run in the foreground. Remind user to stop it when done (Ctrl+C).
+
+## UI Features
+- **Chains View**: See decision chains grouped by goals
+- **Timeline View**: Chronological view of all decisions
+- **Graph View**: Interactive force-directed graph
+- **DAG View**: Directed acyclic graph visualization
+- **Detail Panel**: Click any node to see full details including:
+  - Node metadata (confidence, commit, prompt, files)
+  - Connected nodes (incoming/outgoing edges)
+  - Timestamps and status
+
+## Alternative: Static Hosting
+
+For GitHub Pages or other static hosting:
+```bash
+deciduous sync  # Exports to docs/graph-data.json
+```
+
+Then push to GitHub - the graph is viewable at your GitHub Pages URL.
+
+$ARGUMENTS

--- a/.opencode/command/sync-graph.md
+++ b/.opencode/command/sync-graph.md
@@ -1,0 +1,15 @@
+---
+description: "Export the decision graph to docs/ for GitHub Pages"
+---
+
+# Sync Decision Graph to GitHub Pages
+
+Export the current decision graph to docs/graph-data.json so it's deployed to GitHub Pages.
+
+## Steps
+
+1. Run `deciduous sync` to export the graph
+2. Show the user how many nodes/edges were exported
+3. If there are changes, stage them: `git add docs/graph-data.json`
+
+This should be run before any push to main to ensure the live site has the latest decisions.


### PR DESCRIPTION
## Summary

Adds OpenCode slash commands for streamlined deciduous workflow:

- `/build-test` - Build and run tests
- `/context` - Recover context from decision graph and recent activity
- `/decision` - Manage decision graph nodes and edges
- `/serve-ui` - Start the web UI server
- `/sync-graph` - Export graph data for static hosting

Also includes:
- `.deciduous/config.toml` - Branch configuration for auto-detection
- GitHub workflow to auto-cleanup decision graph PNG/DOT files after PR merge

## Test plan

- [ ] Verify slash commands work in OpenCode
- [ ] Test `/context` recovers session context correctly
- [ ] Test `/decision add goal "test"` creates a node
- [ ] Verify cleanup workflow triggers on PR merge