### PR TITLE
feat: require cargo fmt in pre-commit hooks and CI

### DIFF
--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -8,9 +8,41 @@ on:
   workflow_dispatch:
 
 jobs:
+  format-check:
+    name: Check Code Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check Rust Formatting
+        run: cargo fmt --check
+
+      - name: Format Summary
+        if: success()
+        run: |
+          echo "## Code Formatting ✓" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "All Rust code is properly formatted." >> $GITHUB_STEP_SUMMARY
+
+      - name: Format Failure Summary
+        if: failure()
+        run: |
+          echo "## Code Formatting ✗" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Rust code is not properly formatted!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Run \`cargo fmt\` locally to fix formatting." >> $GITHUB_STEP_SUMMARY
+
   validate-types:
     name: Validate Type Synchronization
     runs-on: ubuntu-latest
+    needs: format-check
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Enforce code formatting via `cargo fmt` at all stages of the development workflow.

### Changes

**Pre-commit hook:**
- Added `cargo fmt --check` as the first check (before clippy)
- Commits with unformatted code are blocked

**Pre-push hook:**
- Added `cargo fmt --check` as step 1/6 in the validation suite
- Pushes to main with unformatted code are blocked

**GitHub Actions CI:**
- Added new `format-check` job that runs `cargo fmt --check`
- All other jobs (`validate-types`, `build-rust`, `build-web`) depend on format passing
- Provides clear failure summary in PR checks

### Error message when code is unformatted:
```
Checking code formatting...

ERROR: Code is not formatted. Commit aborted.
Run 'cargo fmt' to format the code.
```

## Test Plan

- [x] Pre-commit hook blocks unformatted commits locally
- [x] Pre-commit hook passes after running `cargo fmt`
- [ ] CI format-check job fails on unformatted PR
- [ ] CI format-check job passes on formatted code