### PR TITLE
feat: add subagent definitions for domain-specific work

### DIFF
--- a/.claude/agents.toml
+++ b/.claude/agents.toml
@@ -1,0 +1,180 @@
+# Deciduous Project Subagents
+# Domain-specific agents for working on different parts of the codebase.
+#
+# When working on a specific domain, spawn a Task with subagent_type="Explore" or
+# "general-purpose" and include the relevant agent's context in the prompt.
+#
+# Usage: When you identify work belongs to a specific domain, reference this config
+# and scope your exploration/work to the relevant file patterns.
+
+[agents.rust-core]
+name = "Rust Core"
+description = "CLI commands, database layer, export/sync logic"
+file_patterns = [
+    "src/main.rs",
+    "src/db.rs",
+    "src/lib.rs",
+    "src/serve.rs",
+    "src/export.rs",
+    "src/diff.rs",
+    "src/config.rs",
+    "src/schema.rs",
+    "src/github.rs",
+    "src/roadmap.rs",
+    "Cargo.toml",
+    "Cargo.lock"
+]
+exclude_patterns = ["src/tui/**"]
+focus_areas = [
+    "Diesel ORM and SQLite database operations",
+    "CLI command dispatch and argument parsing",
+    "JSON/DOT export and PR writeup generation",
+    "Multi-user sync with diff/patch system",
+    "HTTP server for web UI (serve.rs)"
+]
+instructions = """
+When working on Rust core:
+- Run `cargo test` before and after changes
+- Run `cargo clippy` to check for lints
+- Follow existing patterns in db.rs for database operations
+- Use the macro patterns in export.rs (w!, wln!) for output
+- Maintain backwards compatibility with existing CLI commands
+"""
+
+[agents.tui]
+name = "TUI Agent"
+description = "Terminal UI with Ratatui - views, modals, navigation, keybindings"
+file_patterns = [
+    "src/tui/**/*.rs",
+    "src/tui/app.rs",
+    "src/tui/mod.rs"
+]
+focus_areas = [
+    "Ratatui widgets and rendering",
+    "TEA (The Elm Architecture) pattern - Model/Update/View",
+    "Vim-style navigation (j/k/g/G)",
+    "Modal dialogs and state management",
+    "Syntax highlighting with syntect"
+]
+instructions = """
+When working on TUI:
+- Follow TEA pattern: pure state transformations in state.rs, messages in msg.rs
+- Views should be pure rendering functions with no side effects
+- Test state transformations independently from rendering
+- Use crossterm for terminal events, ratatui for rendering
+- Check src/tui/views/ for existing view implementations
+"""
+
+[agents.web]
+name = "Web Viewer Agent"
+description = "React + TypeScript + D3/Dagre web viewer"
+file_patterns = [
+    "web/src/**/*.ts",
+    "web/src/**/*.tsx",
+    "web/src/views/**",
+    "web/src/components/**",
+    "web/src/hooks/**",
+    "web/src/utils/**",
+    "web/src/types/**",
+    "web/package.json",
+    "web/vite.config.ts",
+    "web/tsconfig.json"
+]
+focus_areas = [
+    "React components and hooks",
+    "D3.js and Dagre for graph visualization",
+    "TypeScript types matching Rust backend",
+    "Vite build system",
+    "URL state management for deep linking"
+]
+instructions = """
+When working on web viewer:
+- After changes, rebuild: cd web && npm run build
+- Copy output: cp web/dist/index.html src/viewer.html
+- Types in web/src/types/graph.ts must match Rust JSON output
+- Run `npm run typecheck` to verify types
+- Test in browser with `deciduous serve`
+"""
+
+[agents.tooling]
+name = "Tooling/Templates Agent"
+description = "Editor integrations, slash commands, rules, and init templates"
+file_patterns = [
+    ".claude/**/*.md",
+    ".claude/**/*.toml",
+    ".windsurf/**/*.md",
+    ".opencode/**/*.md",
+    ".codex/**/*.md",
+    "CLAUDE.md",
+    "AGENTS.md",
+    "src/init.rs"
+]
+focus_areas = [
+    "Claude Code slash commands and configuration",
+    "Windsurf rules and memories",
+    "OpenCode and Codex prompt templates",
+    "Template sync between actual files and src/init.rs",
+    "Editor-agnostic deciduous workflow instructions"
+]
+instructions = """
+When working on tooling:
+- CRITICAL: If you modify .claude/commands/*.md, also update src/init.rs templates
+- Templates in init.rs MUST match actual files to avoid drift
+- Test with: deciduous init --claude (in a temp directory)
+- Each editor has different syntax (frontmatter, triggers, etc.)
+- Keep instructions consistent across all editors
+"""
+
+[agents.docs]
+name = "Documentation Agent"
+description = "User-facing docs, guides, roadmap management"
+file_patterns = [
+    "docs/**/*.html",
+    "docs/**/*.md",
+    "README.md",
+    "ROADMAP.md",
+    "CHANGELOG.md",
+    "docs/tutorial/**"
+]
+exclude_patterns = [
+    "docs/graph-data.json",
+    "docs/git-history.json",
+    "docs/demo/**"
+]
+focus_areas = [
+    "User-facing documentation and guides",
+    "GitHub Pages site content",
+    "Roadmap item management",
+    "Tutorial content"
+]
+instructions = """
+When working on docs:
+- Keep README.md focused on quick start and essentials
+- ROADMAP.md has special HTML comments for tracking - preserve them
+- Tutorial pages should be narrative, not reference docs
+- Run `deciduous sync` to update graph-data.json for the demo
+"""
+
+[agents.ci]
+name = "CI/CD Agent"
+description = "Build scripts, GitHub Actions, release automation"
+file_patterns = [
+    "scripts/**",
+    ".github/workflows/**",
+    ".github/**",
+    "Cargo.toml",
+    "Makefile"
+]
+focus_areas = [
+    "GitHub Actions workflows",
+    "Pre-commit hooks and validation scripts",
+    "Release automation",
+    "Cross-platform builds"
+]
+instructions = """
+When working on CI/CD:
+- Test workflows locally when possible (act or manual simulation)
+- Keep workflows fast - use caching
+- Validate that all checks pass before merging
+- Release process: version bump -> test -> tag -> publish
+"""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,45 @@ deciduous dot --png -o docs/decision-graph.dot
 deciduous writeup -t "Feature X" --nodes 1-15 -o PR-WRITEUP.md
 ```
 
+## Subagents - Domain-Specific Context
+
+**Use subagents to scope work to specific parts of the codebase.**
+
+When working on this project, identify which domain the work belongs to and use the appropriate subagent context. Subagent definitions are in `.claude/agents.toml`.
+
+### Available Subagents
+
+| Agent | Domain | Key Files |
+|-------|--------|-----------|
+| `rust-core` | CLI, database, export/sync | `src/main.rs`, `src/db.rs`, `src/export.rs` |
+| `tui` | Terminal UI with Ratatui | `src/tui/**/*.rs` |
+| `web` | React/TypeScript viewer | `web/src/**/*.{ts,tsx}` |
+| `tooling` | Editor integrations | `.claude/`, `.windsurf/`, `src/init.rs` |
+| `docs` | Documentation, guides | `docs/`, `README.md`, `ROADMAP.md` |
+| `ci` | Build, Actions, releases | `.github/workflows/`, `scripts/` |
+
+### How to Use Subagents
+
+When spawning a Task for exploration or implementation:
+
+1. **Identify the domain** from the file patterns in `.claude/agents.toml`
+2. **Include the subagent context** in your Task prompt
+3. **Scope file searches** to the relevant patterns
+
+Example: For TUI work, spawn an Explore agent with:
+```
+"Focus on src/tui/. This is the TUI agent domain - Ratatui widgets, TEA pattern, vim navigation. See .claude/agents.toml for full context."
+```
+
+### Why Subagents Matter
+
+- **Reduced context overhead**: Focus on relevant files only
+- **Domain expertise**: Each agent has specialized instructions
+- **Parallel work**: Multiple agents can work on different domains simultaneously
+- **Consistency**: Same patterns applied across similar work
+
+---
+
 ## Architecture
 
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,37 +80,39 @@
 ### Subagent System for Codebase Domains
 <!-- roadmap:section id="a1b2c3d4-5e6f-7890-abcd-ef1234567890" -->
 *Specialized agents for each part of the deciduous codebase*
-- [ ] **Set up domain-specific subagents**
+- [x] **Set up domain-specific subagents**
   <!-- roadmap:item id="d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a" outcome_change_id="" -->
   - Each domain gets a specialized agent with focused context and tools
   - Agents can work in parallel on different parts of the codebase
   - Reduces context overhead by scoping to relevant files/patterns
-- [ ] **Rust Core Agent** (`src/` excluding `src/tui/`)
+  - **Implemented**: `.claude/agents.toml` with 6 domain agents
+  - **Integrated**: CLAUDE.md references agents, `deciduous init --claude` creates template
+- [x] **Rust Core Agent** (`src/` excluding `src/tui/`)
   <!-- roadmap:item id="e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b" outcome_change_id="" -->
   - CLI commands, database layer, export/sync logic
   - Diesel ORM, SQLite, command dispatch
   - Focus: `src/main.rs`, `src/db.rs`, `src/lib.rs`, `src/serve.rs`
-- [ ] **TUI Agent** (`src/tui/`)
+- [x] **TUI Agent** (`src/tui/`)
   <!-- roadmap:item id="f6a7b8c9-d0e1-2f3a-4b5c-6d7e8f9a0b1c" outcome_change_id="" -->
   - Terminal UI with Ratatui
   - Views, modals, navigation, keybindings
   - Focus: `src/tui/app.rs`, `src/tui/views/`, `src/tui/widgets/`
-- [ ] **Web Viewer Agent** (`web/`)
+- [x] **Web Viewer Agent** (`web/`)
   <!-- roadmap:item id="a7b8c9d0-e1f2-3a4b-5c6d-7e8f9a0b1c2d" outcome_change_id="" -->
   - React + TypeScript + D3/Dagre
   - Components, hooks, views, styling
   - Focus: `web/src/views/`, `web/src/components/`, `web/src/hooks/`
-- [ ] **Tooling/Templates Agent** (`.claude/`, `.windsurf/`, `CLAUDE.md`, `AGENTS.md`)
+- [x] **Tooling/Templates Agent** (`.claude/`, `.windsurf/`, `CLAUDE.md`, `AGENTS.md`)
   <!-- roadmap:item id="b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e" outcome_change_id="" -->
   - Editor integrations, slash commands, rules
   - Template sync with `src/init.rs`
   - Focus: `.claude/commands/`, `.windsurf/rules/`, tooling docs
-- [ ] **Documentation Agent** (`docs/`, `README.md`, `ROADMAP.md`)
+- [x] **Documentation Agent** (`docs/`, `README.md`, `ROADMAP.md`)
   <!-- roadmap:item id="c9d0e1f2-a3b4-5c6d-7e8f-9a0b1c2d3e4f" outcome_change_id="" -->
   - User-facing docs, guides, roadmap management
   - GitHub Pages content
   - Focus: `docs/`, `README.md`, `ROADMAP.md`, `CHANGELOG.md`
-- [ ] **CI/CD Agent** (`scripts/`, `.github/`)
+- [x] **CI/CD Agent** (`scripts/`, `.github/`)
   <!-- roadmap:item id="d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5a" outcome_change_id="" -->
   - Build scripts, GitHub Actions, release automation
   - Pre-commit hooks, validation

--- a/src/init.rs
+++ b/src/init.rs
@@ -782,6 +782,82 @@ deciduous diff apply --dry-run .deciduous/patches/teammate.json
 PR workflow: Export patch → commit patch file → PR → teammates apply.
 "#;
 
+/// Claude Code agents.toml - defines domain-specific subagents for the project
+/// NOTE: This is a template for NEW projects. The deciduous repo itself has a more
+/// detailed version at .claude/agents.toml that should be kept in sync.
+const CLAUDE_AGENTS_TOML: &str = r#"# Project Subagents Configuration
+# Domain-specific agents for working on different parts of the codebase.
+#
+# When working on a specific domain, spawn a Task with subagent_type="Explore" or
+# "general-purpose" and include the relevant agent's context in the prompt.
+#
+# Customize this file for YOUR project's structure. The domains below are examples.
+
+# Example: Backend/Core agent
+# [agents.backend]
+# name = "Backend Agent"
+# description = "API routes, database models, business logic"
+# file_patterns = [
+#     "src/**/*.rs",
+#     "src/**/*.py",
+#     "app/**/*.py"
+# ]
+# focus_areas = [
+#     "Database operations",
+#     "API endpoints",
+#     "Business logic"
+# ]
+# instructions = """
+# When working on backend:
+# - Run tests before and after changes
+# - Follow existing patterns for new endpoints
+# - Maintain backwards compatibility
+# """
+
+# Example: Frontend agent
+# [agents.frontend]
+# name = "Frontend Agent"
+# description = "UI components, state management, styling"
+# file_patterns = [
+#     "web/src/**/*.ts",
+#     "web/src/**/*.tsx",
+#     "src/components/**"
+# ]
+# focus_areas = [
+#     "React components",
+#     "State management",
+#     "Styling and layout"
+# ]
+# instructions = """
+# When working on frontend:
+# - Test in browser after changes
+# - Follow component patterns
+# - Keep accessibility in mind
+# """
+
+# Example: Infrastructure agent
+# [agents.infra]
+# name = "Infrastructure Agent"
+# description = "CI/CD, deployment, configuration"
+# file_patterns = [
+#     ".github/workflows/**",
+#     "Dockerfile",
+#     "docker-compose.yml",
+#     "scripts/**"
+# ]
+# focus_areas = [
+#     "GitHub Actions",
+#     "Docker configuration",
+#     "Deployment scripts"
+# ]
+# instructions = """
+# When working on infrastructure:
+# - Test workflows locally when possible
+# - Keep builds fast with caching
+# - Document any manual steps
+# """
+"#;
+
 // ============================================================================
 // WINDSURF-SPECIFIC TEMPLATES
 // ============================================================================
@@ -2118,6 +2194,11 @@ pub fn init_project(editor: Editor) -> Result<(), String> {
             // Write context.md slash command
             let context_path = claude_dir.join("context.md");
             write_file_if_missing(&context_path, RECOVER_MD, ".claude/commands/recover.md")?;
+
+            // Write agents.toml for subagent configuration
+            let claude_base = cwd.join(".claude");
+            let agents_path = claude_base.join("agents.toml");
+            write_file_if_missing(&agents_path, CLAUDE_AGENTS_TOML, ".claude/agents.toml")?;
 
             // Append to or create CLAUDE.md
             let claude_md_path = cwd.join("CLAUDE.md");


### PR DESCRIPTION
## Summary

Add configurable subagent system for scoping work to specific codebase domains.

- Add `.claude/agents.toml` with 6 domain agents for deciduous
- Update CLAUDE.md with Subagents section explaining usage
- Update `deciduous init --claude` to create agents.toml template
- Mark subagent roadmap items as completed

## What's New

### `.claude/agents.toml` - Domain Agent Definitions

Each project can now define domain-specific agents with:
- **file_patterns**: Glob patterns for relevant files
- **focus_areas**: What this agent specializes in
- **instructions**: Domain-specific guidance

Example agent definition:
```toml
[agents.rust-core]
name = "Rust Core"
description = "CLI commands, database layer, export/sync logic"
file_patterns = ["src/main.rs", "src/db.rs", "src/export.rs"]
focus_areas = ["Diesel ORM", "CLI dispatch", "JSON export"]
instructions = "Run cargo test before changes..."
```

### Deciduous Agents (for this repo)

| Agent | Domain | Key Files |
|-------|--------|-----------|
| `rust-core` | CLI, database, export/sync | `src/main.rs`, `src/db.rs` |
| `tui` | Terminal UI with Ratatui | `src/tui/**/*.rs` |
| `web` | React/TypeScript viewer | `web/src/**/*.{ts,tsx}` |
| `tooling` | Editor integrations | `.claude/`, `.windsurf/` |
| `docs` | Documentation, guides | `docs/`, `README.md` |
| `ci` | Build, Actions, releases | `.github/workflows/` |

### For New Projects

Running `deciduous init --claude` now creates a template agents.toml with commented examples that users can customize for their project structure.

## Test Plan

- [x] `cargo test` passes (20 tests)
- [x] `cargo build --release` compiles cleanly
- [x] Pre-commit hooks pass (fmt, clippy, types)
- [x] Manual test: `deciduous init --claude` creates `.claude/agents.toml`