### PR TITLE
Fix: OpenCode post-commit hook uses console.error instead of console.log

### DIFF
--- a/.opencode/plugin/post-commit-reminder.ts
+++ b/.opencode/plugin/post-commit-reminder.ts
@@ -32,8 +32,8 @@ export const PostCommitReminder: Plugin = async ({ $ }) => {
         const commitHash = hashResult.stdout.toString().trim()
         const commitMsg = msgResult.stdout.toString().trim().slice(0, 50)
 
-        // Show reminder
-        console.log(`
+        // Show reminder (must use stderr to avoid polluting OpenCode display)
+        console.error(`
 +===================================================================+
 |  DECIDUOUS: Link this commit to the decision graph!               |
 +===================================================================+

--- a/src/opencode.rs
+++ b/src/opencode.rs
@@ -116,8 +116,8 @@ export const PostCommitReminder: Plugin = async ({ $ }) => {
         const commitHash = hashResult.stdout.toString().trim()
         const commitMsg = msgResult.stdout.toString().trim().slice(0, 50)
 
-        // Show reminder
-        console.log(`
+        // Show reminder (must use stderr to avoid polluting OpenCode display)
+        console.error(`
 +===================================================================+
 |  DECIDUOUS: Link this commit to the decision graph!               |
 +===================================================================+


### PR DESCRIPTION
## Summary
- Fix OpenCode post-commit reminder plugin using `console.log` (stdout) instead of `console.error` (stderr)
- OpenCode TUI captures stdout, causing the deciduous reminder banner to render inline in the display panel
- The pre-edit hook was already fixed in v0.13.7; this catches the post-commit hook that was missed

## Files changed
- `src/opencode.rs` - embedded template (affects future `deciduous init`/`deciduous update`)
- `.opencode/plugin/post-commit-reminder.ts` - already-installed plugin in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)