### PR TITLE
ci: make lint gates real — clippy -D warnings, cargo fmt, drop dead proptest step

### DIFF
--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -42,7 +42,6 @@ jobs:
   validate-types:
     name: Validate Type Synchronization
     runs-on: ubuntu-latest
-    needs: format-check
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -60,7 +59,6 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "All type definitions are in sync across:" >> $GITHUB_STEP_SUMMARY
           echo "- \`src/db.rs\` (Rust backend)" >> $GITHUB_STEP_SUMMARY
-          echo "- \`src/tui/types.rs\` (Rust TUI)" >> $GITHUB_STEP_SUMMARY
           echo "- \`web/src/types/graph.ts\` (TypeScript web)" >> $GITHUB_STEP_SUMMARY
           echo "- \`schema/decision-graph.schema.json\` (Canonical schema)" >> $GITHUB_STEP_SUMMARY
 
@@ -73,7 +71,6 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Please ensure all type definitions match across:" >> $GITHUB_STEP_SUMMARY
           echo "- \`src/db.rs\` (Rust backend)" >> $GITHUB_STEP_SUMMARY
-          echo "- \`src/tui/types.rs\` (Rust TUI)" >> $GITHUB_STEP_SUMMARY
           echo "- \`web/src/types/graph.ts\` (TypeScript web)" >> $GITHUB_STEP_SUMMARY
           echo "- \`schema/decision-graph.schema.json\` (Canonical schema)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -81,8 +78,10 @@ jobs:
 
   build-rust:
     name: Build and Test (Rust)
-    runs-on: ubuntu-latest
-    needs: validate-types
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -99,11 +98,8 @@ jobs:
       - name: Rust Integration Tests
         run: cargo test --test cli_integration
 
-      - name: Rust Property Tests (proptest)
-        run: cargo test --lib -- proptests
-
       - name: Rust Clippy
-        run: cargo clippy
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Test Summary
         if: success()
@@ -113,12 +109,11 @@ jobs:
           echo "All Rust tests passed:" >> $GITHUB_STEP_SUMMARY
           echo "- Unit tests" >> $GITHUB_STEP_SUMMARY
           echo "- Integration tests" >> $GITHUB_STEP_SUMMARY
-          echo "- Property-based tests (proptest)" >> $GITHUB_STEP_SUMMARY
+          echo "- Clippy (warnings denied)" >> $GITHUB_STEP_SUMMARY
 
   build-web:
     name: Build Web
     runs-on: ubuntu-latest
-    needs: validate-types
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,21 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,7 +274,6 @@ dependencies = [
  "colored",
  "diesel",
  "libsqlite3-sys",
- "proptest",
  "regex",
  "serde",
  "serde_json",
@@ -654,15 +638,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,31 +645,6 @@ checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "proptest"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
-dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags",
- "num-traits",
- "rand",
- "rand_chacha",
- "rand_xorshift",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
- "unarray",
-]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -720,44 +670,6 @@ dependencies = [
  "log",
  "parking_lot",
  "scheduled-thread-pool",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -816,18 +728,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
 
 [[package]]
 name = "ryu"
@@ -1147,12 +1047,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,15 +1086,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "wasip2"
@@ -1443,23 +1328,3 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
-name = "zerocopy"
-version = "0.8.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,6 @@ all = { level = "deny", priority = -1 }
 too_many_arguments = "allow"
 
 [dev-dependencies]
-proptest = "1.7.0"
 serde_yaml = "0.9.34"
 tempfile = "3.23.0"
 ts-rs = "10.1.0"

--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,10 @@ demo:
 
 # Installation
 install: release
-	cp target/release/losselot /usr/local/bin/
+	cp target/release/deciduous /usr/local/bin/
 
 uninstall:
-	rm -f /usr/local/bin/losselot
+	rm -f /usr/local/bin/deciduous
 
 # Clean build artifacts
 clean:

--- a/src/db.rs
+++ b/src/db.rs
@@ -2723,11 +2723,7 @@ impl Database {
     // ========================================================================
 
     /// Create a new session with an optional name and root goal node.
-    pub fn create_session(
-        &self,
-        name: Option<&str>,
-        root_node_id: Option<i32>,
-    ) -> Result<i32> {
+    pub fn create_session(&self, name: Option<&str>, root_node_id: Option<i32>) -> Result<i32> {
         let mut conn = self.get_conn()?;
         let now = chrono::Local::now().to_rfc3339();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1503,11 +1503,7 @@ fn main() {
                                         "{:<5} {:<12} {:<10} {}",
                                         n.id, type_colored, n.status, n.title
                                     );
-                                    println!(
-                                        "      {:<22} {}",
-                                        "",
-                                        truncated.dimmed()
-                                    );
+                                    println!("      {:<22} {}", "", truncated.dimmed());
                                 } else {
                                     println!(
                                         "{:<5} {:<12} {:<10} {}",

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -388,7 +388,9 @@ fn handle_show_node(db: &Database, args: &Value) -> HandlerResult {
     let children = db.get_node_children(node_id).unwrap_or_default();
     let parents = db.get_node_parents(node_id).unwrap_or_default();
     let themes = db.get_node_themes(node_id).unwrap_or_default();
-    let documents = db.get_node_documents(Some(node_id), false).unwrap_or_default();
+    let documents = db
+        .get_node_documents(Some(node_id), false)
+        .unwrap_or_default();
 
     let mut result = node_to_json(&node);
     if let Some(obj) = result.as_object_mut() {
@@ -402,15 +404,21 @@ fn handle_show_node(db: &Database, args: &Value) -> HandlerResult {
         );
         obj.insert(
             "themes".to_string(),
-            json!(themes.iter().map(|t| json!({"name": t.name, "color": t.color})).collect::<Vec<_>>()),
+            json!(themes
+                .iter()
+                .map(|t| json!({"name": t.name, "color": t.color}))
+                .collect::<Vec<_>>()),
         );
         obj.insert(
             "documents".to_string(),
-            json!(documents.iter().map(|d| json!({
-                "id": d.id,
-                "filename": d.original_filename,
-                "description": d.description,
-            })).collect::<Vec<_>>()),
+            json!(documents
+                .iter()
+                .map(|d| json!({
+                    "id": d.id,
+                    "filename": d.original_filename,
+                    "description": d.description,
+                }))
+                .collect::<Vec<_>>()),
         );
     }
 
@@ -446,12 +454,20 @@ fn handle_search_nodes(db: &Database, args: &Value) -> HandlerResult {
                 .as_ref()
                 .map(|d| d.to_lowercase().contains(&query_lower))
                 .unwrap_or(false);
-            let prompt_match = n.metadata_json.as_ref().map(|m| {
-                serde_json::from_str::<Value>(m)
-                    .ok()
-                    .and_then(|v| v.get("prompt").and_then(Value::as_str).map(|p| p.to_lowercase().contains(&query_lower)))
-                    .unwrap_or(false)
-            }).unwrap_or(false);
+            let prompt_match = n
+                .metadata_json
+                .as_ref()
+                .map(|m| {
+                    serde_json::from_str::<Value>(m)
+                        .ok()
+                        .and_then(|v| {
+                            v.get("prompt")
+                                .and_then(Value::as_str)
+                                .map(|p| p.to_lowercase().contains(&query_lower))
+                        })
+                        .unwrap_or(false)
+                })
+                .unwrap_or(false);
 
             let text_match = title_match || desc_match || prompt_match;
             if !text_match {
@@ -513,8 +529,8 @@ fn handle_attach_document(db: &Database, args: &Value) -> HandlerResult {
         .map(|f| f.to_string_lossy().to_string())
         .unwrap_or_else(|| "unknown".to_string());
 
-    let file_bytes = std::fs::read(path)
-        .map_err(|e| HandlerError::from(format!("Failed to read file: {e}")))?;
+    let file_bytes =
+        std::fs::read(path).map_err(|e| HandlerError::from(format!("Failed to read file: {e}")))?;
 
     let hash = format!("{:x}", Sha256::digest(&file_bytes));
     let hash_prefix = &hash[..8];
@@ -545,7 +561,11 @@ fn handle_attach_document(db: &Database, args: &Value) -> HandlerResult {
             .map_err(|e| HandlerError::from(format!("Failed to write document: {e}")))?;
     }
 
-    let desc_source = if description.is_some() { "manual" } else { "none" };
+    let desc_source = if description.is_some() {
+        "manual"
+    } else {
+        "none"
+    };
     let doc_id = db.attach_document(
         node_id,
         &hash,
@@ -668,7 +688,7 @@ fn handle_trace_chain(db: &Database, args: &Value) -> HandlerResult {
     let node_id = require_i32(args, "node_id")?;
     let max_depth = get_i32(args, "max_depth").unwrap_or(0) as usize;
     let direction = get_str(args, "direction")
-        .map(query::TraceDirection::from_str)
+        .map(query::TraceDirection::parse)
         .unwrap_or(query::TraceDirection::Both);
 
     let graph = db.get_graph()?;
@@ -788,7 +808,9 @@ fn handle_generate_writeup(db: &Database, args: &Value) -> HandlerResult {
     };
 
     let config = crate::export::WriteupConfig {
-        title: title.map(|s| s.to_string()).unwrap_or_else(|| "Decision Graph Writeup".to_string()),
+        title: title
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "Decision Graph Writeup".to_string()),
         root_ids: vec![],
         include_dot: !no_dot,
         include_test_plan: !no_test_plan,
@@ -995,7 +1017,9 @@ mod tests {
     #[test]
     fn test_dispatch_show_node() {
         let db = test_db();
-        let id = db.create_node("goal", "Test Goal", Some("Details here"), Some(90), None).unwrap();
+        let id = db
+            .create_node("goal", "Test Goal", Some("Details here"), Some(90), None)
+            .unwrap();
 
         let result = dispatch(&db, "show_node", json!({"node_id": id}));
         assert!(result.is_error.is_none());
@@ -1017,7 +1041,11 @@ mod tests {
         let db = test_db();
         let id = db.create_node("goal", "Goal", None, None, None).unwrap();
 
-        let result = dispatch(&db, "update_status", json!({"node_id": id, "status": "completed"}));
+        let result = dispatch(
+            &db,
+            "update_status",
+            json!({"node_id": id, "status": "completed"}),
+        );
         assert!(result.is_error.is_none());
 
         let node = db.get_node(id).unwrap().unwrap();
@@ -1027,7 +1055,9 @@ mod tests {
     #[test]
     fn test_dispatch_delete_node_dry_run() {
         let db = test_db();
-        let id = db.create_node("goal", "To delete", None, None, None).unwrap();
+        let id = db
+            .create_node("goal", "To delete", None, None, None)
+            .unwrap();
 
         let result = dispatch(&db, "delete_node", json!({"node_id": id, "dry_run": true}));
         assert!(result.is_error.is_none());
@@ -1040,7 +1070,9 @@ mod tests {
     #[test]
     fn test_dispatch_delete_node_actual() {
         let db = test_db();
-        let id = db.create_node("goal", "To delete", None, None, None).unwrap();
+        let id = db
+            .create_node("goal", "To delete", None, None, None)
+            .unwrap();
 
         let result = dispatch(&db, "delete_node", json!({"node_id": id}));
         assert!(result.is_error.is_none());
@@ -1053,9 +1085,12 @@ mod tests {
     #[test]
     fn test_dispatch_search_nodes() {
         let db = test_db();
-        db.create_node("goal", "Authentication feature", None, None, None).unwrap();
-        db.create_node("action", "Implement JWT tokens", None, None, None).unwrap();
-        db.create_node("goal", "UI redesign", None, None, None).unwrap();
+        db.create_node("goal", "Authentication feature", None, None, None)
+            .unwrap();
+        db.create_node("action", "Implement JWT tokens", None, None, None)
+            .unwrap();
+        db.create_node("goal", "UI redesign", None, None, None)
+            .unwrap();
 
         let result = dispatch(&db, "search_nodes", json!({"query": "auth"}));
         assert!(result.content[0].text.contains("\"count\": 1"));
@@ -1108,7 +1143,11 @@ mod tests {
     fn test_dispatch_create_and_list_themes() {
         let db = test_db();
 
-        let result = dispatch(&db, "create_theme", json!({"name": "auth", "color": "#ff0000"}));
+        let result = dispatch(
+            &db,
+            "create_theme",
+            json!({"name": "auth", "color": "#ff0000"}),
+        );
         assert!(result.is_error.is_none());
 
         let result = dispatch(&db, "list_themes", json!({}));

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -132,11 +132,11 @@ impl McpServer {
                         if result.is_error.is_none() {
                             if let Some(text) = result.content.first().map(|c| &c.text) {
                                 if let Ok(val) = serde_json::from_str::<Value>(text) {
-                                    if let Some(node_id) = val.get("node_id").and_then(Value::as_i64)
+                                    if let Some(node_id) =
+                                        val.get("node_id").and_then(Value::as_i64)
                                     {
-                                        let _ = self
-                                            .db
-                                            .add_node_to_session(session_id, node_id as i32);
+                                        let _ =
+                                            self.db.add_node_to_session(session_id, node_id as i32);
                                     }
                                 }
                             }
@@ -151,10 +151,7 @@ impl McpServer {
         serde_json::to_value(result).map_err(|e| json!({"error": e.to_string()}))
     }
 
-    fn handle_start_session(
-        &mut self,
-        args: &Value,
-    ) -> protocol::ToolCallResult {
+    fn handle_start_session(&mut self, args: &Value) -> protocol::ToolCallResult {
         let name = args
             .get("name")
             .and_then(Value::as_str)
@@ -179,7 +176,9 @@ impl McpServer {
             None,
         ) {
             Ok(id) => id,
-            Err(e) => return protocol::tool_result_error(format!("Failed to create root goal: {e}")),
+            Err(e) => {
+                return protocol::tool_result_error(format!("Failed to create root goal: {e}"))
+            }
         };
 
         // Create the session
@@ -207,10 +206,7 @@ impl McpServer {
         }))
     }
 
-    fn handle_end_session(
-        &mut self,
-        args: &Value,
-    ) -> protocol::ToolCallResult {
+    fn handle_end_session(&mut self, args: &Value) -> protocol::ToolCallResult {
         let session_id = match self.active_session_id {
             Some(id) => id,
             None => return protocol::tool_result_error("No active session to end"),
@@ -241,10 +237,7 @@ impl McpServer {
         }))
     }
 
-    fn handle_resume_session(
-        &mut self,
-        args: &Value,
-    ) -> protocol::ToolCallResult {
+    fn handle_resume_session(&mut self, args: &Value) -> protocol::ToolCallResult {
         let session_id = match args.get("session_id").and_then(Value::as_i64) {
             Some(id) => id as i32,
             None => return protocol::tool_result_error("Missing required parameter: session_id"),
@@ -290,10 +283,7 @@ impl McpServer {
         }))
     }
 
-    fn handle_get_session(
-        &self,
-        args: &Value,
-    ) -> protocol::ToolCallResult {
+    fn handle_get_session(&self, args: &Value) -> protocol::ToolCallResult {
         let session_id = args
             .get("session_id")
             .and_then(Value::as_i64)
@@ -302,12 +292,16 @@ impl McpServer {
 
         let session_id = match session_id {
             Some(id) => id,
-            None => return protocol::tool_result_error("No session ID provided and no active session"),
+            None => {
+                return protocol::tool_result_error("No session ID provided and no active session")
+            }
         };
 
         let session = match self.db.get_session(session_id) {
             Ok(Some(s)) => s,
-            Ok(None) => return protocol::tool_result_error(format!("Session {session_id} not found")),
+            Ok(None) => {
+                return protocol::tool_result_error(format!("Session {session_id} not found"))
+            }
             Err(e) => return protocol::tool_result_error(format!("Error: {e}")),
         };
 
@@ -338,10 +332,7 @@ impl McpServer {
         }))
     }
 
-    fn handle_list_sessions(
-        &self,
-        args: &Value,
-    ) -> protocol::ToolCallResult {
+    fn handle_list_sessions(&self, args: &Value) -> protocol::ToolCallResult {
         let active_only = args
             .get("active_only")
             .and_then(Value::as_bool)
@@ -565,7 +556,10 @@ mod tests {
         let resp = server.handle_message("not json at all");
         assert!(resp.is_some());
         let resp = resp.unwrap();
-        assert_eq!(resp["error"]["code"].as_i64().unwrap(), protocol::PARSE_ERROR);
+        assert_eq!(
+            resp["error"]["code"].as_i64().unwrap(),
+            protocol::PARSE_ERROR
+        );
     }
 
     #[test]
@@ -699,7 +693,9 @@ mod tests {
         assert!(server.active_session_id.is_none());
 
         // Resume it
-        let msg = format!(r#"{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"resume_session","arguments":{{"session_id":{session_id}}}}}}}"#);
+        let msg = format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"resume_session","arguments":{{"session_id":{session_id}}}}}}}"#
+        );
         let resp = server.handle_message(&msg).unwrap();
         let text = resp["result"]["content"][0]["text"].as_str().unwrap();
         assert!(text.contains("Resumed session"));

--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -422,8 +422,6 @@ mod tests {
         assert!(value.get("protocolVersion").is_some());
         assert!(value.get("serverInfo").is_some());
         assert!(value["serverInfo"].get("name").is_some());
-        assert!(value["capabilities"]["tools"]
-            .get("listChanged")
-            .is_some());
+        assert!(value["capabilities"]["tools"].get("listChanged").is_some());
     }
 }

--- a/src/mcp/query.rs
+++ b/src/mcp/query.rs
@@ -25,7 +25,7 @@ pub enum TraceDirection {
 }
 
 impl TraceDirection {
-    pub fn from_str(s: &str) -> Self {
+    pub fn parse(s: &str) -> Self {
         match s.to_lowercase().as_str() {
             "outgoing" => Self::Outgoing,
             "incoming" => Self::Incoming,
@@ -68,14 +68,8 @@ pub fn trace_chain(
         }
 
         let neighbors: Vec<i32> = match direction {
-            TraceDirection::Outgoing => outgoing
-                .get(&node_id)
-                .cloned()
-                .unwrap_or_default(),
-            TraceDirection::Incoming => incoming
-                .get(&node_id)
-                .cloned()
-                .unwrap_or_default(),
+            TraceDirection::Outgoing => outgoing.get(&node_id).cloned().unwrap_or_default(),
+            TraceDirection::Incoming => incoming.get(&node_id).cloned().unwrap_or_default(),
             TraceDirection::Both => {
                 let mut all = outgoing.get(&node_id).cloned().unwrap_or_default();
                 all.extend(incoming.get(&node_id).cloned().unwrap_or_default());
@@ -786,7 +780,9 @@ mod tests {
     #[test]
     fn test_find_orphans_disconnected_action() {
         let mut graph = sample_graph();
-        graph.nodes.push(make_node(7, "action", "Dangling action", Some("main")));
+        graph
+            .nodes
+            .push(make_node(7, "action", "Dangling action", Some("main")));
 
         let orphans = find_orphans(&graph);
         assert_eq!(orphans.len(), 1);
@@ -871,7 +867,9 @@ mod tests {
     #[test]
     fn test_orphans_to_json() {
         let mut graph = sample_graph();
-        graph.nodes.push(make_node(7, "outcome", "Lost outcome", None));
+        graph
+            .nodes
+            .push(make_node(7, "outcome", "Lost outcome", None));
         let orphans = find_orphans(&graph);
         let json = orphans_to_json(&orphans);
         assert!(json["count"].as_u64().unwrap() > 0);
@@ -901,17 +899,18 @@ mod tests {
     }
 
     #[test]
-    fn test_trace_direction_from_str() {
-        assert_eq!(TraceDirection::from_str("outgoing"), TraceDirection::Outgoing);
-        assert_eq!(TraceDirection::from_str("incoming"), TraceDirection::Incoming);
-        assert_eq!(TraceDirection::from_str("both"), TraceDirection::Both);
-        assert_eq!(TraceDirection::from_str("unknown"), TraceDirection::Both);
+    fn test_trace_direction_parse() {
+        assert_eq!(TraceDirection::parse("outgoing"), TraceDirection::Outgoing);
+        assert_eq!(TraceDirection::parse("incoming"), TraceDirection::Incoming);
+        assert_eq!(TraceDirection::parse("both"), TraceDirection::Both);
+        assert_eq!(TraceDirection::parse("unknown"), TraceDirection::Both);
     }
 
     #[test]
     fn test_node_summary_json_unpacks_metadata() {
         let mut node = make_node(1, "goal", "Test", Some("main"));
-        node.metadata_json = Some(r#"{"confidence":85,"branch":"main","commit":"abc123"}"#.to_string());
+        node.metadata_json =
+            Some(r#"{"confidence":85,"branch":"main","commit":"abc123"}"#.to_string());
         let j = node_summary_json(&node);
         assert_eq!(j["confidence"], 85);
         assert_eq!(j["branch"], "main");

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -795,7 +795,10 @@ mod tests {
             "update_status",
             "update_prompt",
         ] {
-            assert!(names.contains(&name.to_string()), "Missing CRUD tool: {name}");
+            assert!(
+                names.contains(&name.to_string()),
+                "Missing CRUD tool: {name}"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

First PR in a 7-part improvement series. All PRs are behavior-preserving — no features change, no version bump needed.

- **Fix the broken clippy run**: `TraceDirection::from_str` tripped `clippy::should_implement_trait`, which is denied via `[lints.clippy] all = deny`, so `cargo clippy` errored outright. Renamed to `TraceDirection::parse` (infallible, so implementing `FromStr` would be wrong).
- **Make the repo fmt-clean**: `cargo fmt --check` was failing on main (10 files), which means the existing `format-check` CI job was red. Ran `cargo fmt`.
- **CI hardening** (`type-check.yml`):
  - Clippy now gates: `cargo clippy --all-targets -- -D warnings` (matches the Makefile `lint` target; CI was weaker than local)
  - Jobs run in parallel instead of a serial `needs` chain (~halves wall clock)
  - macOS added to the build/test matrix (releases ship macOS binaries; CI only tested Linux)
  - Removed the dead proptest step — there are zero proptest tests in the repo, so the "Property-based tests" summary line misrepresented coverage. Dropped the unused `proptest` dev-dependency too.
  - Removed stale `src/tui/types.rs` references from job summaries (no tui module exists)
- **Makefile**: `make install`/`uninstall` still referenced the pre-rename `losselot` binary and were broken; now they use `deciduous`.

## Test plan
- `cargo test` — 272 tests pass
- `cargo clippy --all-targets -- -D warnings` — clean (0 warnings)
- `cargo fmt --check` — clean
- `cargo build --release` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)