### PR TITLE
fix: core bug fixes — UTF-8 panic, unlink sync divergence, DB atomicity, false success, DST panic

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -679,6 +679,25 @@ impl From<diesel::r2d2::Error> for DbError {
 
 pub type Result<T> = std::result::Result<T, DbError>;
 
+/// r2d2 connection customizer that sets a busy timeout on every acquired
+/// connection so concurrent writers (CLI + serve + MCP) wait instead of
+/// failing immediately with SQLITE_BUSY "database is locked".
+#[derive(Debug)]
+struct BusyTimeoutCustomizer;
+
+impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
+    for BusyTimeoutCustomizer
+{
+    fn on_acquire(
+        &self,
+        conn: &mut SqliteConnection,
+    ) -> std::result::Result<(), diesel::r2d2::Error> {
+        use diesel::connection::SimpleConnection;
+        conn.batch_execute("PRAGMA busy_timeout = 5000;")
+            .map_err(diesel::r2d2::Error::QueryError)
+    }
+}
+
 impl Database {
     /// Get the database path that will be used
     pub fn db_path() -> std::path::PathBuf {
@@ -708,6 +727,7 @@ impl Database {
         let manager = ConnectionManager::<SqliteConnection>::new(&path_str);
         let pool = Pool::builder()
             .max_size(5)
+            .connection_customizer(Box::new(BusyTimeoutCustomizer))
             .build(manager)
             .map_err(|e| DbError::Connection(e.to_string()))?;
 
@@ -1459,14 +1479,18 @@ impl Database {
             created_at: &now,
         };
 
-        diesel::insert_into(decision_edges::table)
-            .values(&new_edge)
-            .execute(&mut conn)?;
+        let id = conn.transaction::<i32, DbError, _>(|conn| {
+            diesel::insert_into(decision_edges::table)
+                .values(&new_edge)
+                .execute(conn)?;
 
-        let id: i32 = diesel::select(diesel::dsl::sql::<diesel::sql_types::Integer>(
-            "last_insert_rowid()",
-        ))
-        .first(&mut conn)?;
+            let id: i32 = diesel::select(diesel::dsl::sql::<diesel::sql_types::Integer>(
+                "last_insert_rowid()",
+            ))
+            .first(conn)?;
+
+            Ok(id)
+        })?;
 
         Ok(id)
     }
@@ -1480,6 +1504,16 @@ impl Database {
         rationale: Option<&str>,
     ) -> Result<i32> {
         self.create_edge(from_id, to_id, edge_type, rationale)
+    }
+
+    /// Get all edges between two nodes (there may be multiple with different edge types)
+    pub fn get_edges_between(&self, from_id: i32, to_id: i32) -> Result<Vec<DecisionEdge>> {
+        let mut conn = self.get_conn()?;
+        let edges = decision_edges::table
+            .filter(decision_edges::from_node_id.eq(from_id))
+            .filter(decision_edges::to_node_id.eq(to_id))
+            .load::<DecisionEdge>(&mut conn)?;
+        Ok(edges)
     }
 
     /// Delete an edge between two nodes
@@ -1566,44 +1600,48 @@ impl Database {
             return Ok(summary);
         }
 
-        // Delete in order to respect foreign key constraints:
+        // Delete in order to respect foreign key constraints, atomically so a
+        // failure partway through cannot leave orphaned rows behind:
+        conn.transaction::<(), DbError, _>(|conn| {
+            // 1. Delete edges connected to this node
+            diesel::delete(
+                decision_edges::table.filter(
+                    decision_edges::from_node_id
+                        .eq(node_id)
+                        .or(decision_edges::to_node_id.eq(node_id)),
+                ),
+            )
+            .execute(conn)?;
 
-        // 1. Delete edges connected to this node
-        diesel::delete(
-            decision_edges::table.filter(
-                decision_edges::from_node_id
-                    .eq(node_id)
-                    .or(decision_edges::to_node_id.eq(node_id)),
-            ),
-        )
-        .execute(&mut conn)?;
+            // 2. Delete context entries for this node
+            diesel::delete(decision_context::table.filter(decision_context::node_id.eq(node_id)))
+                .execute(conn)?;
 
-        // 2. Delete context entries for this node
-        diesel::delete(decision_context::table.filter(decision_context::node_id.eq(node_id)))
-            .execute(&mut conn)?;
+            // 3. Delete session_nodes entries for this node
+            diesel::delete(session_nodes::table.filter(session_nodes::node_id.eq(node_id)))
+                .execute(conn)?;
 
-        // 3. Delete session_nodes entries for this node
-        diesel::delete(session_nodes::table.filter(session_nodes::node_id.eq(node_id)))
-            .execute(&mut conn)?;
+            // 4. Set nullable foreign keys to NULL
+            diesel::update(
+                decision_sessions::table.filter(decision_sessions::root_node_id.eq(node_id)),
+            )
+            .set(decision_sessions::root_node_id.eq::<Option<i32>>(None))
+            .execute(conn)?;
 
-        // 4. Set nullable foreign keys to NULL
-        diesel::update(
-            decision_sessions::table.filter(decision_sessions::root_node_id.eq(node_id)),
-        )
-        .set(decision_sessions::root_node_id.eq::<Option<i32>>(None))
-        .execute(&mut conn)?;
+            diesel::update(command_log::table.filter(command_log::decision_node_id.eq(node_id)))
+                .set(command_log::decision_node_id.eq::<Option<i32>>(None))
+                .execute(conn)?;
 
-        diesel::update(command_log::table.filter(command_log::decision_node_id.eq(node_id)))
-            .set(command_log::decision_node_id.eq::<Option<i32>>(None))
-            .execute(&mut conn)?;
+            diesel::update(roadmap_items::table.filter(roadmap_items::outcome_node_id.eq(node_id)))
+                .set(roadmap_items::outcome_node_id.eq::<Option<i32>>(None))
+                .execute(conn)?;
 
-        diesel::update(roadmap_items::table.filter(roadmap_items::outcome_node_id.eq(node_id)))
-            .set(roadmap_items::outcome_node_id.eq::<Option<i32>>(None))
-            .execute(&mut conn)?;
+            // 5. Finally delete the node itself
+            diesel::delete(decision_nodes::table.filter(decision_nodes::id.eq(node_id)))
+                .execute(conn)?;
 
-        // 5. Finally delete the node itself
-        diesel::delete(decision_nodes::table.filter(decision_nodes::id.eq(node_id)))
-            .execute(&mut conn)?;
+            Ok(())
+        })?;
 
         Ok(summary)
     }
@@ -1613,12 +1651,19 @@ impl Database {
         let mut conn = self.get_conn()?;
         let now = chrono::Local::now().to_rfc3339();
 
-        diesel::update(decision_nodes::table.filter(decision_nodes::id.eq(node_id)))
-            .set((
-                decision_nodes::status.eq(status),
-                decision_nodes::updated_at.eq(&now),
-            ))
-            .execute(&mut conn)?;
+        let rows_updated =
+            diesel::update(decision_nodes::table.filter(decision_nodes::id.eq(node_id)))
+                .set((
+                    decision_nodes::status.eq(status),
+                    decision_nodes::updated_at.eq(&now),
+                ))
+                .execute(&mut conn)?;
+
+        if rows_updated == 0 {
+            // Match update_node_prompt/update_node_commit, which surface a
+            // NotFound query error when the node doesn't exist
+            return Err(DbError::Query(diesel::result::Error::NotFound));
+        }
 
         Ok(())
     }
@@ -3661,5 +3706,148 @@ mod tests {
         let json = serde_json::to_string(&graph).unwrap();
         assert!(json.contains("\"documents\""));
         assert!(json.contains("file.txt"));
+    }
+
+    // === delete_node cascade Tests ===
+
+    #[test]
+    fn test_delete_node_cascades_edges_and_sessions() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::new(dir.path().join("test.db").to_str().unwrap()).unwrap();
+
+        let a = db.create_node("goal", "Parent", None, None, None).unwrap();
+        let b = db.create_node("action", "Child", None, None, None).unwrap();
+        let c = db
+            .create_node("outcome", "Result", None, None, None)
+            .unwrap();
+        db.create_edge(a, b, "leads_to", Some("parent-child"))
+            .unwrap();
+        db.create_edge(b, c, "leads_to", None).unwrap();
+
+        // Session rows referencing the node
+        let session_id = db.create_session(Some("s"), Some(b)).unwrap();
+        db.add_node_to_session(session_id, b).unwrap();
+
+        let summary = db.delete_node(b, false).unwrap();
+        assert_eq!(summary.edges_deleted, 2);
+
+        // Node is gone
+        assert!(db.get_node(b).unwrap().is_none());
+
+        // All edges touching the node are gone
+        let edges = db.get_all_edges().unwrap();
+        assert!(edges
+            .iter()
+            .all(|e| e.from_node_id != b && e.to_node_id != b));
+        assert!(db.get_edges_between(a, b).unwrap().is_empty());
+        assert!(db.get_edges_between(b, c).unwrap().is_empty());
+
+        // Session root is nulled and session membership removed
+        let session = db.get_session(session_id).unwrap().unwrap();
+        assert_eq!(session.root_node_id, None);
+        assert!(db.get_session_nodes(session_id).unwrap().is_empty());
+
+        // Other nodes are untouched
+        assert!(db.get_node(a).unwrap().is_some());
+        assert!(db.get_node(c).unwrap().is_some());
+    }
+
+    #[test]
+    fn test_delete_node_dry_run_keeps_everything() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::new(dir.path().join("test.db").to_str().unwrap()).unwrap();
+
+        let a = db.create_node("goal", "Parent", None, None, None).unwrap();
+        let b = db.create_node("action", "Child", None, None, None).unwrap();
+        db.create_edge(a, b, "leads_to", None).unwrap();
+
+        let summary = db.delete_node(b, true).unwrap();
+        assert_eq!(summary.edges_deleted, 1);
+
+        assert!(db.get_node(b).unwrap().is_some());
+        assert_eq!(db.get_edges_between(a, b).unwrap().len(), 1);
+    }
+
+    // === update_node_status Tests ===
+
+    #[test]
+    fn test_update_node_status_nonexistent_returns_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::new(dir.path().join("test.db").to_str().unwrap()).unwrap();
+
+        let result = db.update_node_status(9999, "completed");
+        assert!(
+            result.is_err(),
+            "updating a nonexistent node should be an error"
+        );
+    }
+
+    #[test]
+    fn test_update_node_status_existing_node() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::new(dir.path().join("test.db").to_str().unwrap()).unwrap();
+
+        let id = db.create_node("goal", "G", None, None, None).unwrap();
+        db.update_node_status(id, "completed").unwrap();
+        assert_eq!(db.get_node(id).unwrap().unwrap().status, "completed");
+    }
+
+    // === get_edges_between / unlink edge_id Tests ===
+
+    #[test]
+    fn test_get_edges_between_returns_real_edge_type() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::new(dir.path().join("test.db").to_str().unwrap()).unwrap();
+
+        let a = db
+            .create_node("option", "Option A", None, None, None)
+            .unwrap();
+        let b = db
+            .create_node("decision", "Decision", None, None, None)
+            .unwrap();
+        db.create_edge(a, b, "rejected", Some("not chosen"))
+            .unwrap();
+
+        let edges = db.get_edges_between(a, b).unwrap();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].edge_type, "rejected");
+
+        // No edge in the other direction
+        assert!(db.get_edges_between(b, a).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_unlink_edge_id_matches_creation_edge_id() {
+        // Regression test: DeleteEdge events must use the edge's REAL type so
+        // the edge_id matches the one emitted by AddEdge at creation time.
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::new(dir.path().join("test.db").to_str().unwrap()).unwrap();
+
+        let a = db
+            .create_node("option", "Option A", None, None, None)
+            .unwrap();
+        let b = db
+            .create_node("decision", "Decision", None, None, None)
+            .unwrap();
+        db.create_edge(a, b, "rejected", None).unwrap();
+
+        let from = db.get_node(a).unwrap().unwrap();
+        let to = db.get_node(b).unwrap().unwrap();
+
+        // The id emitted when the edge was created (link path)
+        let created_id =
+            crate::events::generate_edge_id(&from.change_id, &to.change_id, "rejected");
+
+        // The id the unlink path now derives from the actual stored edge
+        let edge = &db.get_edges_between(a, b).unwrap()[0];
+        let deleted_id =
+            crate::events::generate_edge_id(&from.change_id, &to.change_id, &edge.edge_type);
+
+        assert_eq!(created_id, deleted_id);
+
+        // The previously hardcoded "leads_to" id would NOT have matched
+        let hardcoded_id =
+            crate::events::generate_edge_id(&from.change_id, &to.change_id, "leads_to");
+        assert_ne!(deleted_id, hardcoded_id);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1079,31 +1079,7 @@ fn main() {
             });
 
             // Parse date parameter into RFC3339 format
-            let effective_date = date.as_ref().map(|d| {
-                // Try parsing as RFC3339 first
-                if chrono::DateTime::parse_from_rfc3339(d).is_ok() {
-                    d.clone()
-                }
-                // Try "YYYY-MM-DD HH:MM:SS" format
-                else if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(d, "%Y-%m-%d %H:%M:%S")
-                {
-                    chrono::Local.from_local_datetime(&dt).unwrap().to_rfc3339()
-                }
-                // Try "YYYY-MM-DD" format (set to start of day)
-                else if let Ok(date) = chrono::NaiveDate::parse_from_str(d, "%Y-%m-%d") {
-                    let dt = date.and_hms_opt(0, 0, 0).unwrap();
-                    chrono::Local.from_local_datetime(&dt).unwrap().to_rfc3339()
-                }
-                // Fallback: use as-is and hope for the best
-                else {
-                    eprintln!(
-                        "{} Could not parse date '{}'. Use RFC3339 or YYYY-MM-DD format.",
-                        "Warning:".yellow(),
-                        d
-                    );
-                    d.clone()
-                }
-            });
+            let effective_date = date.as_ref().map(|d| parse_backdate(d));
 
             match db.create_node_full(
                 &node_type,
@@ -1122,7 +1098,7 @@ fn main() {
                         .unwrap_or_default();
                     let commit_str = effective_commit
                         .as_ref()
-                        .map(|c| format!(" [commit: {}]", &c[..7.min(c.len())]))
+                        .map(|c| format!(" [commit: {}]", c.chars().take(7).collect::<String>()))
                         .unwrap_or_default();
                     let prompt_str = effective_prompt
                         .as_ref()
@@ -1241,9 +1217,12 @@ fn main() {
         },
 
         Command::Unlink { from, to } => {
-            // Get node info before deletion for event emission
+            // Get node and edge info before deletion for event emission.
+            // delete_edge removes ALL edges between the pair, so capture every
+            // edge's type to emit matching DeleteEdge events.
             let from_node = db.get_node(from).ok().flatten();
             let to_node = db.get_node(to).ok().flatten();
+            let deleted_edges = db.get_edges_between(from, to).unwrap_or_default();
 
             match db.delete_edge(from, to) {
                 Ok(()) => {
@@ -1257,20 +1236,28 @@ fn main() {
                             if let Ok(event_log) =
                                 EventLog::new(&PathBuf::from(".deciduous"), author.clone())
                             {
-                                // We need to figure out the edge_type for the edge_id
-                                // For now, use "leads_to" as default since we don't have the edge info
-                                let edge_id = generate_edge_id(
-                                    &from_n.change_id,
-                                    &to_n.change_id,
-                                    "leads_to",
-                                );
-                                let event = Event::DeleteEdge {
-                                    edge_id,
-                                    timestamp: chrono::Utc::now(),
-                                    author,
-                                };
-                                if let Err(e) = event_log.append(event) {
-                                    eprintln!("{} Sync event: {}", "Warning:".yellow(), e);
+                                // Emit one DeleteEdge per deleted edge, using each
+                                // edge's real type so the edge_id matches the one
+                                // emitted when the edge was created
+                                let mut emitted_ids: Vec<String> = Vec::new();
+                                for edge in &deleted_edges {
+                                    let edge_id = generate_edge_id(
+                                        &from_n.change_id,
+                                        &to_n.change_id,
+                                        &edge.edge_type,
+                                    );
+                                    if emitted_ids.contains(&edge_id) {
+                                        continue;
+                                    }
+                                    emitted_ids.push(edge_id.clone());
+                                    let event = Event::DeleteEdge {
+                                        edge_id,
+                                        timestamp: chrono::Utc::now(),
+                                        author: author.clone(),
+                                    };
+                                    if let Err(e) = event_log.append(event) {
+                                        eprintln!("{} Sync event: {}", "Warning:".yellow(), e);
+                                    }
                                 }
                             }
                         }
@@ -1494,11 +1481,7 @@ fn main() {
                             };
                             if n.node_type == "observation" {
                                 if let Some(ref desc) = n.description {
-                                    let truncated = if desc.len() > 80 {
-                                        format!("{}...", &desc[..77])
-                                    } else {
-                                        desc.clone()
-                                    };
+                                    let truncated = truncate(desc, 80);
                                     println!(
                                         "{:<5} {:<12} {:<10} {}",
                                         n.id, type_colored, n.status, n.title
@@ -4548,6 +4531,41 @@ fn generate_ai_description(filename: &str, file_path: &std::path::Path) -> Optio
     }
 }
 
+/// Parse a `--date` value into RFC3339, accepting RFC3339, "YYYY-MM-DD HH:MM:SS",
+/// or "YYYY-MM-DD" (start of day). Local times that don't exist (DST gaps) or are
+/// ambiguous resolve via `earliest()` instead of panicking; unparseable input is
+/// passed through as-is with a warning.
+fn parse_backdate(d: &str) -> String {
+    // Try parsing as RFC3339 first
+    if chrono::DateTime::parse_from_rfc3339(d).is_ok() {
+        return d.to_string();
+    }
+
+    // Try "YYYY-MM-DD HH:MM:SS" format
+    let naive = chrono::NaiveDateTime::parse_from_str(d, "%Y-%m-%d %H:%M:%S")
+        .ok()
+        // Try "YYYY-MM-DD" format (set to start of day)
+        .or_else(|| {
+            chrono::NaiveDate::parse_from_str(d, "%Y-%m-%d")
+                .ok()
+                .and_then(|date| date.and_hms_opt(0, 0, 0))
+        });
+
+    if let Some(dt) = naive {
+        if let Some(local) = chrono::Local.from_local_datetime(&dt).earliest() {
+            return local.to_rfc3339();
+        }
+    }
+
+    // Fallback: use as-is and hope for the best
+    eprintln!(
+        "{} Could not parse date '{}'. Use RFC3339 or YYYY-MM-DD format.",
+        "Warning:".yellow(),
+        d
+    );
+    d.to_string()
+}
+
 fn truncate(s: &str, max_len: usize) -> String {
     if s.chars().count() <= max_len {
         s.to_string()
@@ -4835,5 +4853,88 @@ mod tests {
             "Real example should have high match, got {}",
             score
         );
+    }
+
+    // === truncate Tests ===
+
+    #[test]
+    fn test_truncate_short_string_unchanged() {
+        assert_eq!(truncate("hello", 80), "hello");
+    }
+
+    #[test]
+    fn test_truncate_long_ascii() {
+        let s = "a".repeat(100);
+        let result = truncate(&s, 80);
+        assert_eq!(result.chars().count(), 80);
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn test_truncate_multibyte_at_boundary() {
+        // Regression test: byte-slicing `&desc[..77]` panicked when a
+        // multi-byte character straddled the boundary. Cyrillic chars are
+        // 2 bytes each, so every odd byte index is mid-character.
+        let s = "\u{0434}".repeat(100); // "д" x 100 (200 bytes)
+        let result = truncate(&s, 80);
+        assert_eq!(result.chars().count(), 80);
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn test_truncate_emoji_description() {
+        // 4-byte emoji near the boundary must not panic
+        let s = format!("{}{}", "x".repeat(76), "\u{1F600}".repeat(10));
+        let result = truncate(&s, 80);
+        assert_eq!(result.chars().count(), 80);
+        assert!(result.ends_with("..."));
+    }
+
+    // === parse_backdate Tests ===
+
+    #[test]
+    fn test_parse_backdate_rfc3339_passthrough() {
+        let input = "2025-01-15T10:30:00+00:00";
+        assert_eq!(parse_backdate(input), input);
+    }
+
+    #[test]
+    fn test_parse_backdate_date_only() {
+        let result = parse_backdate("2025-01-15");
+        let parsed = chrono::DateTime::parse_from_rfc3339(&result)
+            .expect("date-only input should produce valid RFC3339");
+        assert!(result.starts_with("2025-01-15"), "got {}", result);
+        let _ = parsed;
+    }
+
+    #[test]
+    fn test_parse_backdate_datetime() {
+        let result = parse_backdate("2025-01-15 10:30:00");
+        assert!(
+            chrono::DateTime::parse_from_rfc3339(&result).is_ok(),
+            "datetime input should produce valid RFC3339, got {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_parse_backdate_dst_gap_does_not_panic() {
+        // Regression test: 2:30 AM on 2025-03-09 does not exist in US
+        // timezones (DST spring-forward). The old code called .unwrap() on
+        // from_local_datetime and panicked. Depending on the host timezone
+        // this either resolves to a valid RFC3339 time or falls back to
+        // passing the input through -- but it must never panic.
+        let input = "2025-03-09 02:30:00";
+        let result = parse_backdate(input);
+        assert!(
+            result == input || chrono::DateTime::parse_from_rfc3339(&result).is_ok(),
+            "expected passthrough or valid RFC3339, got {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_parse_backdate_garbage_passthrough() {
+        assert_eq!(parse_backdate("not a date"), "not a date");
     }
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -232,6 +232,68 @@ fn test_add_all_node_types() {
     }
 }
 
+#[test]
+fn test_nodes_with_multibyte_observation_description() {
+    // Regression test: `deciduous nodes` truncated long observation
+    // descriptions by byte index, panicking when a multi-byte character
+    // straddled the 77-byte boundary.
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let db_path = temp_dir.path().join("test.db");
+
+    // Description well over 80 chars, made entirely of 4-byte emoji so any
+    // byte-index truncation lands mid-character
+    let long_desc = "\u{1F600}".repeat(100);
+    let output = run_deciduous(
+        &["add", "observation", "Emoji Observation", "-d", &long_desc],
+        &db_path,
+    );
+    assert!(
+        output.status.success(),
+        "add observation failed: {}",
+        stderr(&output)
+    );
+
+    let output = run_deciduous(&["nodes"], &db_path);
+    assert!(
+        output.status.success(),
+        "nodes panicked or failed on multibyte description: {}",
+        stderr(&output)
+    );
+    let out = stdout(&output);
+    assert!(out.contains("Emoji Observation"));
+    assert!(out.contains("..."), "long description should be truncated");
+}
+
+#[test]
+fn test_add_node_with_dst_gap_date() {
+    // Regression test: --date with a local time that does not exist in the
+    // process timezone (DST spring-forward gap) panicked on .unwrap().
+    // 2:30 AM on 2025-03-09 does not exist in America/New_York.
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let db_path = temp_dir.path().join("test.db");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_deciduous"))
+        .args([
+            "add",
+            "goal",
+            "DST Gap Goal",
+            "--date",
+            "2025-03-09 02:30:00",
+        ])
+        .env("DECIDUOUS_DB_PATH", &db_path)
+        .env("TZ", "America/New_York")
+        .output()
+        .expect("Failed to execute deciduous");
+    assert!(
+        output.status.success(),
+        "add with DST-gap date failed: {}",
+        stderr(&output)
+    );
+
+    let output = run_deciduous(&["nodes"], &db_path);
+    assert!(stdout(&output).contains("DST Gap Goal"));
+}
+
 // =============================================================================
 // Edge Tests
 // =============================================================================
@@ -320,6 +382,20 @@ fn test_update_node_status() {
     // Verify status changed
     let output = run_deciduous(&["nodes"], &db_path);
     assert!(stdout(&output).contains("completed"));
+}
+
+#[test]
+fn test_update_status_nonexistent_node_fails() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let db_path = temp_dir.path().join("test.db");
+
+    // No nodes exist - updating status must fail, not silently succeed
+    let output = run_deciduous(&["status", "42", "completed"], &db_path);
+    assert!(
+        !output.status.success(),
+        "status update on nonexistent node should fail, stdout: {}",
+        stdout(&output)
+    );
 }
 
 // =============================================================================
@@ -550,6 +626,35 @@ fn test_unlink_nodes() {
         output.status.success(),
         "unlink failed: {}",
         stderr(&output)
+    );
+}
+
+#[test]
+fn test_unlink_non_leads_to_edge() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let db_path = temp_dir.path().join("test.db");
+
+    // Create nodes linked with a non-default edge type
+    run_deciduous(&["add", "option", "Option A"], &db_path);
+    run_deciduous(&["add", "decision", "Decision"], &db_path);
+    run_deciduous(&["link", "1", "2", "-t", "rejected"], &db_path);
+
+    // Verify the typed edge exists
+    let output = run_deciduous(&["edges"], &db_path);
+    assert!(stdout(&output).contains("rejected"));
+
+    // Unlink removes it
+    let output = run_deciduous(&["unlink", "1", "2"], &db_path);
+    assert!(
+        output.status.success(),
+        "unlink failed: {}",
+        stderr(&output)
+    );
+
+    let output = run_deciduous(&["edges"], &db_path);
+    assert!(
+        !stdout(&output).contains("rejected"),
+        "typed edge should be removed"
     );
 }
 


### PR DESCRIPTION
## Summary

Part 3 of the series (stacked on #202). Five verified bugs fixed, plus a concurrency hardening, all with regression tests. No feature or CLI surface changes.

1. **UTF-8 panic in `deciduous nodes`** — observation descriptions were truncated with a raw byte slice (`&desc[..77]`), which panics on any multi-byte character straddling the boundary (emoji, CJK, accents). Now uses the existing Unicode-safe `truncate()` helper. Same class of fix for user-supplied `--commit` values.
2. **`unlink` silently broke multi-user sync** — the `DeleteEdge` event hardcoded `edge_type: "leads_to"` when computing the `edge_id`. Since edge ids hash `(from, to, type)`, deleting a `rejected`/`blocks`/`chosen` edge emitted an id that never matched the original `AddEdge` — teammates running `events rebuild` kept the deleted edge forever. Now fetches the real edges via a new `Database::get_edges_between()` and emits one correctly-typed event per deleted edge.
3. **No transactions around multi-step mutations** — `delete_node` runs a 7-statement cascade; a mid-sequence failure (I/O error, `SQLITE_BUSY`) left a partially-deleted graph. The cascade and `create_edge`'s insert+rowid now run in transactions.
4. **`status` reported success for nonexistent nodes** — `deciduous status 99999 completed` printed "Updated" while touching nothing. Now returns NotFound, consistent with `update_node_prompt`/`update_node_commit`.
5. **DST-gap panic in `--date`** — `from_local_datetime().unwrap()` panics on local times that don't exist (spring-forward). Extracted `parse_backdate()` using `.earliest()` with the existing warn-and-passthrough fallback.
6. **`PRAGMA busy_timeout = 5000` on every pooled connection** — CLI, `serve`, and the MCP server can all write concurrently; without a busy timeout, contended writers failed instantly with "database is locked".

## Test plan
- 19 new regression tests: delete-node cascade, edge-id round-trip for non-`leads_to` edges, multibyte truncation, status-on-missing-node, and a true DST regression test (`TZ=America/New_York` + `--date "2025-03-09 02:30:00"`) that panicked before the fix
- `cargo test` — 291 pass · `cargo clippy --all-targets -- -D warnings` — clean · `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)