### PR TITLE
fix(mcp): resume_session data loss, JSON-RPC id echo, pulse consistency, tool caching

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2807,6 +2807,25 @@ impl Database {
         Ok(())
     }
 
+    /// Reactivate an ended session (clear ended_at, leaving the summary untouched).
+    pub fn reactivate_session(&self, session_id: i32) -> Result<()> {
+        let mut conn = self.get_conn()?;
+
+        let updated =
+            diesel::update(decision_sessions::table.filter(decision_sessions::id.eq(session_id)))
+                .set(decision_sessions::ended_at.eq(None::<String>))
+                .execute(&mut conn)?;
+
+        if updated == 0 {
+            return Err(DbError::Validation(format!(
+                "Session {} not found",
+                session_id
+            )));
+        }
+
+        Ok(())
+    }
+
     /// Associate a node with a session.
     pub fn add_node_to_session(&self, session_id: i32, node_id: i32) -> Result<()> {
         let mut conn = self.get_conn()?;

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -533,7 +533,7 @@ fn handle_attach_document(db: &Database, args: &Value) -> HandlerResult {
         std::fs::read(path).map_err(|e| HandlerError::from(format!("Failed to read file: {e}")))?;
 
     let hash = format!("{:x}", Sha256::digest(&file_bytes));
-    let hash_prefix = &hash[..8];
+    let hash_prefix = hash.get(..8).unwrap_or(hash.as_str());
     let storage_filename = format!("{original_filename}.{hash_prefix}");
     let file_size = file_bytes.len() as i32;
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -16,7 +16,8 @@ pub mod tools;
 use crate::db::Database;
 use protocol::{
     build_initialize_result, error_response, parse_request, success_response, tool_result_error,
-    JsonRpcErrorResponse, ToolCallParams, ToolListResult, METHOD_NOT_FOUND,
+    JsonRpcErrorResponse, ToolCallParams, ToolListResult, INTERNAL_ERROR, INVALID_PARAMS,
+    METHOD_NOT_FOUND,
 };
 use serde_json::{json, Value};
 use std::io::{self, BufRead, Write};
@@ -75,9 +76,9 @@ impl McpServer {
         };
 
         let result = match request.method.as_str() {
-            "initialize" => handle_initialize(request.params),
-            "tools/list" => handle_tools_list(),
-            "tools/call" => self.handle_tools_call(request.params),
+            "initialize" => handle_initialize(&id, request.params),
+            "tools/list" => handle_tools_list(&id),
+            "tools/call" => self.handle_tools_call(&id, request.params),
             "ping" => Ok(json!({})),
             method => Err(error_to_value(error_response(
                 id.clone(),
@@ -92,13 +93,17 @@ impl McpServer {
         })
     }
 
-    fn handle_tools_call(&mut self, params: Option<Value>) -> Result<Value, Value> {
+    fn handle_tools_call(&mut self, id: &Value, params: Option<Value>) -> Result<Value, Value> {
         let params = params.ok_or_else(|| {
-            json!({"jsonrpc":"2.0","id":null,"error":{"code":-32602,"message":"Missing params"}})
+            error_to_value(error_response(id.clone(), INVALID_PARAMS, "Missing params"))
         })?;
 
         let call: ToolCallParams = serde_json::from_value(params).map_err(|e| {
-            json!({"jsonrpc":"2.0","id":null,"error":{"code":-32602,"message":format!("Invalid params: {e}")}})
+            error_to_value(error_response(
+                id.clone(),
+                INVALID_PARAMS,
+                format!("Invalid params: {e}"),
+            ))
         })?;
 
         if !tools::is_valid_tool(&call.name) {
@@ -106,13 +111,13 @@ impl McpServer {
                 "Unknown tool: {}. Use tools/list to see available tools.",
                 call.name
             ));
-            return serde_json::to_value(result).map_err(|e| json!({"error": e.to_string()}));
+            return serde_json::to_value(result).map_err(|e| serialization_error(id, &e));
         }
 
         let args = call.arguments.unwrap_or(json!({}));
         if let Err(msg) = tools::validate_tool_args(&call.name, &args) {
             let result = tool_result_error(msg);
-            return serde_json::to_value(result).map_err(|e| json!({"error": e.to_string()}));
+            return serde_json::to_value(result).map_err(|e| serialization_error(id, &e));
         }
 
         // Session lifecycle tools need mutable access to server state
@@ -148,7 +153,7 @@ impl McpServer {
             }
         };
 
-        serde_json::to_value(result).map_err(|e| json!({"error": e.to_string()}))
+        serde_json::to_value(result).map_err(|e| serialization_error(id, &e))
     }
 
     fn handle_start_session(&mut self, args: &Value) -> protocol::ToolCallResult {
@@ -254,13 +259,9 @@ impl McpServer {
 
         // Reopen if it was ended
         if session.ended_at.is_some() {
-            // Clear ended_at to reactivate
-            if let Err(e) = self.db.end_session(session_id, None) {
+            if let Err(e) = self.db.reactivate_session(session_id) {
                 return protocol::tool_result_error(format!("Failed to reopen session: {e}"));
             }
-            // end_session sets ended_at, but we want to clear it — use raw update
-            // For now, just create a fresh session that continues the tree
-            eprintln!("deciduous-mcp: note - session #{session_id} was ended, resuming anyway");
         }
 
         self.active_session_id = Some(session_id);
@@ -384,9 +385,11 @@ fn load_session_from_disk(db: &Database) -> Option<i32> {
     }
 }
 
-/// Persist active session ID to disk.
+/// Persist active session ID to disk. Non-fatal on failure, but logged.
 fn save_session_to_disk(session_id: i32) {
-    let _ = std::fs::write(SESSION_FILE, session_id.to_string());
+    if let Err(e) = std::fs::write(SESSION_FILE, session_id.to_string()) {
+        eprintln!("deciduous-mcp: failed to persist session #{session_id} to {SESSION_FILE}: {e}");
+    }
 }
 
 /// Remove the session file from disk.
@@ -452,7 +455,7 @@ fn handle_notification(method: &str) {
     }
 }
 
-fn handle_initialize(params: Option<Value>) -> Result<Value, Value> {
+fn handle_initialize(id: &Value, params: Option<Value>) -> Result<Value, Value> {
     if let Some(ref p) = params {
         if let Some(info) = p.get("clientInfo") {
             let name = info
@@ -464,13 +467,22 @@ fn handle_initialize(params: Option<Value>) -> Result<Value, Value> {
     }
 
     let result = build_initialize_result();
-    serde_json::to_value(result).map_err(|e| json!({"error": e.to_string()}))
+    serde_json::to_value(result).map_err(|e| serialization_error(id, &e))
 }
 
-fn handle_tools_list() -> Result<Value, Value> {
-    let tools = tools::all_tool_definitions();
+fn handle_tools_list(id: &Value) -> Result<Value, Value> {
+    let tools = tools::tool_definitions().to_vec();
     let result = ToolListResult { tools };
-    serde_json::to_value(result).map_err(|e| json!({"error": e.to_string()}))
+    serde_json::to_value(result).map_err(|e| serialization_error(id, &e))
+}
+
+/// Build a proper JSON-RPC error envelope for a serialization failure.
+fn serialization_error(id: &Value, e: &serde_json::Error) -> Value {
+    error_to_value(error_response(
+        id.clone(),
+        INTERNAL_ERROR,
+        format!("Serialization error: {e}"),
+    ))
 }
 
 fn error_to_value(err: JsonRpcErrorResponse) -> Value {
@@ -705,6 +717,76 @@ mod tests {
         server.handle_message(r#"{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"add_node","arguments":{"node_type":"action","title":"After resume"}}}"#);
         let nodes = server.db.get_session_nodes(session_id).unwrap();
         assert!(nodes.iter().any(|n| n.title == "After resume"));
+    }
+
+    #[test]
+    fn test_resume_ended_session_reactivates_and_preserves_summary() {
+        let mut server = test_server();
+
+        // Start a session, then end it WITH a summary
+        server.handle_message(r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"start_session","arguments":{"name":"reopen test","goal_title":"Reopen me"}}}"#);
+        let session_id = server.active_session_id.unwrap();
+        server.handle_message(r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"end_session","arguments":{"summary":"Important summary"}}}"#);
+
+        // Sanity: session is ended with the summary saved
+        let session = server.db.get_session(session_id).unwrap().unwrap();
+        assert!(session.ended_at.is_some());
+        assert_eq!(session.summary.as_deref(), Some("Important summary"));
+
+        // Resume it
+        let msg = format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"resume_session","arguments":{{"session_id":{session_id}}}}}}}"#
+        );
+        server.handle_message(&msg).unwrap();
+
+        // ended_at must be cleared, summary must be preserved
+        let session = server.db.get_session(session_id).unwrap().unwrap();
+        assert!(
+            session.ended_at.is_none(),
+            "resume must clear ended_at so the session reads as active"
+        );
+        assert_eq!(
+            session.summary.as_deref(),
+            Some("Important summary"),
+            "resume must not wipe the saved summary"
+        );
+
+        // And the get_session tool should report it as active with the summary intact
+        let resp = server.handle_message(r#"{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_session","arguments":{}}}"#).unwrap();
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("\"is_active\": true"));
+        assert!(text.contains("Important summary"));
+    }
+
+    #[test]
+    fn test_tools_call_missing_params_echoes_request_id() {
+        let mut server = test_server();
+
+        // tools/call with no params at all
+        let msg = r#"{"jsonrpc":"2.0","id":42,"method":"tools/call"}"#;
+        let resp = server.handle_message(msg).unwrap();
+        assert_eq!(resp["id"], 42, "error response must echo the request id");
+        assert_eq!(
+            resp["error"]["code"].as_i64().unwrap(),
+            protocol::INVALID_PARAMS
+        );
+    }
+
+    #[test]
+    fn test_tools_call_invalid_params_shape_echoes_request_id() {
+        let mut server = test_server();
+
+        // params present but missing the required "name" field
+        let msg = r#"{"jsonrpc":"2.0","id":"req-7","method":"tools/call","params":{"bogus":true}}"#;
+        let resp = server.handle_message(msg).unwrap();
+        assert_eq!(
+            resp["id"], "req-7",
+            "error response must echo the request id"
+        );
+        assert_eq!(
+            resp["error"]["code"].as_i64().unwrap(),
+            protocol::INVALID_PARAMS
+        );
     }
 
     #[test]

--- a/src/mcp/query.rs
+++ b/src/mcp/query.rs
@@ -269,7 +269,14 @@ pub fn get_pulse(graph: &DecisionGraph, branch: Option<&str>, recent_count: usiz
         *nodes_by_status.entry(n.status.clone()).or_insert(0) += 1;
     }
 
-    let orphan_nodes = find_orphans(graph);
+    // Apply the same branch filter to orphans so the report is internally consistent
+    let orphan_nodes: Vec<OrphanNode> = find_orphans(graph)
+        .into_iter()
+        .filter(|o| match branch {
+            Some(b) => node_has_branch(&o.node, b),
+            None => true,
+        })
+        .collect();
     let orphan_count = orphan_nodes.len();
 
     let active_goals: Vec<DecisionNode> = filtered_nodes
@@ -310,38 +317,31 @@ pub struct OrphanNode {
 /// Goals are valid orphans (root nodes). Other types should have parents.
 pub fn find_orphans(graph: &DecisionGraph) -> Vec<OrphanNode> {
     let nodes_with_incoming: HashSet<i32> = graph.edges.iter().map(|e| e.to_node_id).collect();
-    let nodes_with_outgoing: HashSet<i32> = graph.edges.iter().map(|e| e.from_node_id).collect();
 
     graph
         .nodes
         .iter()
         .filter_map(|n| {
-            let has_incoming = nodes_with_incoming.contains(&n.id);
-            let has_outgoing = nodes_with_outgoing.contains(&n.id);
-
             // Goals are valid root nodes — skip them
             if n.node_type == "goal" {
                 return None;
             }
 
-            if !has_incoming {
-                Some(OrphanNode {
-                    node: n.clone(),
-                    reason: match n.node_type.as_str() {
-                        "outcome" => "Outcome without parent action".to_string(),
-                        "action" => "Action without parent decision".to_string(),
-                        "decision" => "Decision without parent option".to_string(),
-                        "option" => "Option without parent goal".to_string(),
-                        "observation" => "Observation not linked to any node".to_string(),
-                        _ => format!("{} without incoming edges", n.node_type),
-                    },
-                })
-            } else if !has_outgoing && n.node_type != "outcome" && n.node_type != "observation" {
-                // Leaf nodes: outcomes and observations are fine without outgoing edges
-                None
-            } else {
-                None
+            if nodes_with_incoming.contains(&n.id) {
+                return None;
             }
+
+            Some(OrphanNode {
+                node: n.clone(),
+                reason: match n.node_type.as_str() {
+                    "outcome" => "Outcome without parent action".to_string(),
+                    "action" => "Action without parent decision".to_string(),
+                    "decision" => "Decision without parent option".to_string(),
+                    "option" => "Option without parent goal".to_string(),
+                    "observation" => "Observation not linked to any node".to_string(),
+                    _ => format!("{} without incoming edges", n.node_type),
+                },
+            })
         })
         .collect()
 }
@@ -765,6 +765,37 @@ mod tests {
         let graph = sample_graph();
         let report = get_pulse(&graph, Some("nonexistent"), 10);
         assert_eq!(report.total_nodes, 0);
+    }
+
+    #[test]
+    fn test_pulse_branch_filter_orphans_consistent() {
+        // Orphan action on branch-a; connected goal -> action on branch-b
+        let graph = DecisionGraph {
+            nodes: vec![
+                make_node(1, "action", "Dangling on a", Some("branch-a")),
+                make_node(2, "goal", "Goal on b", Some("branch-b")),
+                make_node(3, "action", "Action on b", Some("branch-b")),
+            ],
+            edges: vec![make_edge(1, 2, 3, "leads_to")],
+            config: None,
+            themes: vec![],
+            node_themes: vec![],
+            documents: vec![],
+        };
+
+        // Branch B has no orphans — the branch-a orphan must not leak in
+        let report_b = get_pulse(&graph, Some("branch-b"), 10);
+        assert_eq!(report_b.orphan_count, 0);
+        assert!(report_b.orphan_nodes.is_empty());
+
+        // Branch A reports exactly its own orphan
+        let report_a = get_pulse(&graph, Some("branch-a"), 10);
+        assert_eq!(report_a.orphan_count, 1);
+        assert_eq!(report_a.orphan_nodes[0].node.id, 1);
+
+        // No filter still sees the orphan
+        let report_all = get_pulse(&graph, None, 10);
+        assert_eq!(report_all.orphan_count, 1);
     }
 
     // -- orphan tests --

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -5,11 +5,21 @@
 
 use crate::mcp::protocol::ToolDefinition;
 use serde_json::{json, Value};
+use std::sync::OnceLock;
+
+/// Cached tool definitions — built once on first access, reused across requests.
+static TOOLS: OnceLock<Vec<ToolDefinition>> = OnceLock::new();
+
+/// Get the cached tool definitions, building them on first access.
+pub fn tool_definitions() -> &'static [ToolDefinition] {
+    TOOLS.get_or_init(all_tool_definitions)
+}
 
 /// Build the complete list of tool definitions for `tools/list`.
 ///
 /// Each tool has a name, description, and JSON Schema for its parameters.
-/// This is a pure function — returns fresh data each call.
+/// This is a pure function — returns fresh data each call. Prefer
+/// [`tool_definitions`] for lookups; it caches the result.
 pub fn all_tool_definitions() -> Vec<ToolDefinition> {
     vec![
         // -----------------------------------------------------------------
@@ -636,25 +646,28 @@ pub fn all_tool_definitions() -> Vec<ToolDefinition> {
 
 /// Look up a tool definition by name. Returns None if not found.
 pub fn find_tool(name: &str) -> Option<ToolDefinition> {
-    all_tool_definitions().into_iter().find(|t| t.name == name)
+    tool_definitions().iter().find(|t| t.name == name).cloned()
 }
 
 /// Get all tool names as a sorted list.
 pub fn tool_names() -> Vec<String> {
-    let mut names: Vec<String> = all_tool_definitions().into_iter().map(|t| t.name).collect();
+    let mut names: Vec<String> = tool_definitions().iter().map(|t| t.name.clone()).collect();
     names.sort();
     names
 }
 
 /// Validate that a tool name exists in the registry.
 pub fn is_valid_tool(name: &str) -> bool {
-    all_tool_definitions().iter().any(|t| t.name == name)
+    tool_definitions().iter().any(|t| t.name == name)
 }
 
 /// Validate tool arguments against the tool's input schema.
 /// Returns Ok(()) if valid, Err(message) if invalid.
 pub fn validate_tool_args(tool_name: &str, args: &Value) -> Result<(), String> {
-    let tool = find_tool(tool_name).ok_or_else(|| format!("Unknown tool: {tool_name}"))?;
+    let tool = tool_definitions()
+        .iter()
+        .find(|t| t.name == tool_name)
+        .ok_or_else(|| format!("Unknown tool: {tool_name}"))?;
 
     let schema = &tool.input_schema;
 
@@ -681,6 +694,17 @@ pub fn validate_tool_args(tool_name: &str, args: &Value) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_tool_definitions_cache_matches_all_tool_definitions() {
+        let cached: Vec<&str> = tool_definitions().iter().map(|t| t.name.as_str()).collect();
+        let fresh = all_tool_definitions();
+        let fresh_names: Vec<&str> = fresh.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(
+            cached, fresh_names,
+            "cached tool definitions must not drift from all_tool_definitions()"
+        );
+    }
 
     #[test]
     fn test_all_tools_have_valid_schemas() {


### PR DESCRIPTION
## Summary

Part 4 of the series (stacked on #203). Fixes in the v0.15.0 MCP server, all covered by tests.

- **`resume_session` destroyed data**: to reopen an ended session it called `end_session(id, None)`, which re-stamped `ended_at` (so the session still read as inactive everywhere) and overwrote the user's saved summary with NULL. A new `Database::reactivate_session()` clears only `ended_at` and preserves the summary. The old test passed because it only checked in-memory state — the new regression test asserts DB state and summary survival.
- **JSON-RPC protocol fix**: `tools/call` param errors returned `"id": null` instead of echoing the request id, breaking client response correlation (spec violation). Serialization-failure fallbacks also emitted bare `{"error": ...}` objects instead of JSON-RPC envelopes. Both now go through `error_response` with the real id.
- **`get_pulse` consistency**: with a branch filter, totals were branch-scoped but orphans were computed on the whole graph — an internally contradictory report. Orphans now respect the filter.
- **Dead code**: removed `find_orphans`' never-taken `has_outgoing` arms.
- **Perf**: the 31 tool definitions were rebuilt from `json!` literals at least twice per `tools/call`; now cached in a `OnceLock` (MSRV 1.70-safe).
- **Robustness**: session persistence write failures are now logged instead of silently swallowed; document-hash prefix slicing can't panic.

## Test plan
- 5 new tests: ended-session resume round-trip (ended_at cleared + summary preserved), id echo for missing/invalid params (integer and string ids), branch-filtered orphan consistency, cache-vs-fresh tool definition parity
- `cargo test` — 296 pass · clippy `-D warnings` clean · fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)