### PR TITLE
refactor: remove ~600 lines of duplication — shared tables, metadata accessors, event helper

### DIFF
--- a/src/archaeology.rs
+++ b/src/archaeology.rs
@@ -36,25 +36,6 @@ pub struct SupersededNode {
     pub title: String,
 }
 
-fn get_branch(node: &DecisionNode) -> Option<String> {
-    node.metadata_json
-        .as_ref()
-        .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
-        .and_then(|v| {
-            v.get("branch")
-                .and_then(|b| b.as_str())
-                .map(|s| s.to_string())
-        })
-}
-
-fn get_confidence(node: &DecisionNode) -> Option<u8> {
-    node.metadata_json
-        .as_ref()
-        .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
-        .and_then(|v| v.get("confidence").and_then(|c| c.as_u64()))
-        .map(|c| c.min(100) as u8)
-}
-
 /// Create a full pivot chain atomically.
 ///
 /// Performs these steps:
@@ -97,7 +78,7 @@ pub fn create_pivot(
     }
 
     // Inherit branch from the source node
-    let branch = get_branch(&from_node);
+    let branch = from_node.branch();
 
     // Step 2: Create observation node
     let obs_id = db
@@ -319,7 +300,7 @@ pub fn timeline(
 
     // Filter by branch
     if let Some(br) = branch {
-        nodes.retain(|n| get_branch(n).as_deref() == Some(br));
+        nodes.retain(|n| n.branch().as_deref() == Some(br));
     }
 
     // Sort chronologically (already sorted by created_at asc from DB, but re-sort to be safe)
@@ -346,7 +327,8 @@ pub fn print_timeline(nodes: &[DecisionNode]) {
 
     for node in nodes {
         let date = node.created_at.get(..10).unwrap_or(&node.created_at);
-        let conf = get_confidence(node)
+        let conf = node
+            .confidence()
             .map(|c| format!(" {}%", c))
             .unwrap_or_default();
         let status_color = match node.status.as_str() {

--- a/src/db.rs
+++ b/src/db.rs
@@ -231,6 +231,49 @@ pub struct DecisionNode {
     pub metadata_json: Option<String>,
 }
 
+impl DecisionNode {
+    /// Parse `metadata_json` into a JSON value (None if absent or malformed)
+    pub fn metadata(&self) -> Option<serde_json::Value> {
+        self.metadata_json
+            .as_ref()
+            .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+    }
+
+    /// Extract the branch name from metadata
+    pub fn branch(&self) -> Option<String> {
+        self.metadata().and_then(|v| {
+            v.get("branch")
+                .and_then(|b| b.as_str())
+                .map(|s| s.to_string())
+        })
+    }
+
+    /// Extract the confidence from metadata (clamped to 100, matching build_metadata_json)
+    pub fn confidence(&self) -> Option<u8> {
+        self.metadata()
+            .and_then(|v| v.get("confidence").and_then(|c| c.as_u64()))
+            .map(|c| c.min(100) as u8)
+    }
+
+    /// Extract the commit hash from metadata
+    pub fn commit(&self) -> Option<String> {
+        self.metadata().and_then(|v| {
+            v.get("commit")
+                .and_then(|c| c.as_str())
+                .map(|s| s.to_string())
+        })
+    }
+
+    /// Extract the stored prompt from metadata
+    pub fn prompt(&self) -> Option<String> {
+        self.metadata().and_then(|v| {
+            v.get("prompt")
+                .and_then(|p| p.as_str())
+                .map(|s| s.to_string())
+        })
+    }
+}
+
 /// Summary of what was deleted by delete_node
 #[derive(Debug)]
 pub struct DeleteSummary {
@@ -698,6 +741,61 @@ impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
     }
 }
 
+/// Check whether the `change_id` column exists on decision_nodes
+fn has_node_change_id_column(conn: &mut SqliteConnection) -> bool {
+    let columns: Vec<PragmaTableInfo> = diesel::sql_query("PRAGMA table_info(decision_nodes)")
+        .load(conn)
+        .unwrap_or_default();
+    columns.iter().any(|c| c.name == "change_id")
+}
+
+/// Backfill NULL node change_ids with fresh UUIDs. Returns the number of rows backfilled.
+fn backfill_null_node_change_ids(conn: &mut SqliteConnection) -> Result<usize> {
+    let nodes: Vec<NodeIdOnly> =
+        diesel::sql_query("SELECT id FROM decision_nodes WHERE change_id IS NULL")
+            .load(conn)
+            .unwrap_or_default();
+
+    let count = nodes.len();
+    for node in nodes {
+        let change_id = Uuid::new_v4().to_string();
+        diesel::sql_query(format!(
+            "UPDATE decision_nodes SET change_id = '{}' WHERE id = {}",
+            change_id, node.id
+        ))
+        .execute(conn)?;
+    }
+    Ok(count)
+}
+
+/// Add from_change_id/to_change_id columns to decision_edges and backfill them
+/// from node change_ids. Returns true if the columns were added, false if they
+/// already existed.
+fn add_edge_change_id_columns(conn: &mut SqliteConnection) -> Result<bool> {
+    let edge_columns: Vec<PragmaTableInfo> = diesel::sql_query("PRAGMA table_info(decision_edges)")
+        .load(conn)
+        .unwrap_or_default();
+
+    let has_from_change_id = edge_columns.iter().any(|c| c.name == "from_change_id");
+
+    if has_from_change_id {
+        return Ok(false);
+    }
+
+    diesel::sql_query("ALTER TABLE decision_edges ADD COLUMN from_change_id TEXT").execute(conn)?;
+    diesel::sql_query("ALTER TABLE decision_edges ADD COLUMN to_change_id TEXT").execute(conn)?;
+
+    // Backfill edge change_ids from node change_ids
+    diesel::sql_query(
+        "UPDATE decision_edges SET
+            from_change_id = (SELECT change_id FROM decision_nodes WHERE id = decision_edges.from_node_id),
+            to_change_id = (SELECT change_id FROM decision_nodes WHERE id = decision_edges.to_node_id)"
+    )
+    .execute(conn)?;
+
+    Ok(true)
+}
+
 impl Database {
     /// Get the database path that will be used
     pub fn db_path() -> std::path::PathBuf {
@@ -753,12 +851,7 @@ impl Database {
             return Ok(false); // Table doesn't exist yet, init_schema will create it
         }
 
-        // Check if change_id column exists in decision_nodes
-        let columns: Vec<PragmaTableInfo> = diesel::sql_query("PRAGMA table_info(decision_nodes)")
-            .load(&mut conn)
-            .unwrap_or_default();
-
-        let has_change_id = columns.iter().any(|c| c.name == "change_id");
+        let has_change_id = has_node_change_id_column(&mut conn);
 
         if !has_change_id {
             // Add change_id column to decision_nodes
@@ -767,46 +860,14 @@ impl Database {
         }
 
         // Always backfill any NULL change_ids (handles both new columns and stragglers)
-        let nodes: Vec<NodeIdOnly> =
-            diesel::sql_query("SELECT id FROM decision_nodes WHERE change_id IS NULL")
-                .load(&mut conn)
-                .unwrap_or_default();
+        let backfilled = backfill_null_node_change_ids(&mut conn)?;
 
-        if nodes.is_empty() && has_change_id {
+        if backfilled == 0 && has_change_id {
             return Ok(false); // Already fully migrated
         }
 
-        for node in nodes {
-            let change_id = Uuid::new_v4().to_string();
-            diesel::sql_query(format!(
-                "UPDATE decision_nodes SET change_id = '{}' WHERE id = {}",
-                change_id, node.id
-            ))
-            .execute(&mut conn)?;
-        }
-
         // Check if edge columns need migration
-        let edge_columns: Vec<PragmaTableInfo> =
-            diesel::sql_query("PRAGMA table_info(decision_edges)")
-                .load(&mut conn)
-                .unwrap_or_default();
-
-        let has_from_change_id = edge_columns.iter().any(|c| c.name == "from_change_id");
-
-        if !has_from_change_id {
-            diesel::sql_query("ALTER TABLE decision_edges ADD COLUMN from_change_id TEXT")
-                .execute(&mut conn)?;
-            diesel::sql_query("ALTER TABLE decision_edges ADD COLUMN to_change_id TEXT")
-                .execute(&mut conn)?;
-
-            // Backfill edge change_ids
-            diesel::sql_query(
-                "UPDATE decision_edges SET
-                    from_change_id = (SELECT change_id FROM decision_nodes WHERE id = decision_edges.from_node_id),
-                    to_change_id = (SELECT change_id FROM decision_nodes WHERE id = decision_edges.to_node_id)"
-            )
-            .execute(&mut conn)?;
-        }
+        add_edge_change_id_columns(&mut conn)?;
 
         Ok(true) // Migration performed
     }
@@ -1231,15 +1292,7 @@ impl Database {
     pub fn migrate_add_change_ids(&self) -> Result<bool> {
         let mut conn = self.get_conn()?;
 
-        // Check if change_id column exists in decision_nodes
-        let columns: Vec<(String,)> = diesel::sql_query("PRAGMA table_info(decision_nodes)")
-            .load::<PragmaTableInfo>(&mut conn)
-            .map(|rows| rows.into_iter().map(|r| (r.name,)).collect())
-            .unwrap_or_default();
-
-        let has_change_id = columns.iter().any(|(name,)| name == "change_id");
-
-        if has_change_id {
+        if has_node_change_id_column(&mut conn) {
             return Ok(false); // Already migrated
         }
 
@@ -1248,47 +1301,14 @@ impl Database {
             .execute(&mut conn)?;
 
         // Backfill change_id with UUIDs for existing nodes
-        let nodes: Vec<(i32,)> =
-            diesel::sql_query("SELECT id FROM decision_nodes WHERE change_id IS NULL")
-                .load::<NodeIdOnly>(&mut conn)
-                .map(|rows| rows.into_iter().map(|r| (r.id,)).collect())
-                .unwrap_or_default();
-
-        for (node_id,) in nodes {
-            let change_id = Uuid::new_v4().to_string();
-            diesel::sql_query(format!(
-                "UPDATE decision_nodes SET change_id = '{}' WHERE id = {}",
-                change_id, node_id
-            ))
-            .execute(&mut conn)?;
-        }
+        backfill_null_node_change_ids(&mut conn)?;
 
         // Create unique index on change_id
         diesel::sql_query("CREATE UNIQUE INDEX IF NOT EXISTS idx_nodes_change_id_unique ON decision_nodes(change_id)")
             .execute(&mut conn)?;
 
         // Add from_change_id and to_change_id columns to decision_edges
-        let edge_columns: Vec<(String,)> = diesel::sql_query("PRAGMA table_info(decision_edges)")
-            .load::<PragmaTableInfo>(&mut conn)
-            .map(|rows| rows.into_iter().map(|r| (r.name,)).collect())
-            .unwrap_or_default();
-
-        let has_from_change_id = edge_columns.iter().any(|(name,)| name == "from_change_id");
-
-        if !has_from_change_id {
-            diesel::sql_query("ALTER TABLE decision_edges ADD COLUMN from_change_id TEXT")
-                .execute(&mut conn)?;
-            diesel::sql_query("ALTER TABLE decision_edges ADD COLUMN to_change_id TEXT")
-                .execute(&mut conn)?;
-
-            // Backfill edge change_ids from node change_ids
-            diesel::sql_query(
-                "UPDATE decision_edges SET
-                    from_change_id = (SELECT change_id FROM decision_nodes WHERE id = decision_edges.from_node_id),
-                    to_change_id = (SELECT change_id FROM decision_nodes WHERE id = decision_edges.to_node_id)"
-            )
-            .execute(&mut conn)?;
-
+        if add_edge_change_id_columns(&mut conn)? {
             // Create indexes
             diesel::sql_query("CREATE INDEX IF NOT EXISTS idx_edges_from_change ON decision_edges(from_change_id)")
                 .execute(&mut conn)?;
@@ -1800,19 +1820,7 @@ impl Database {
 
     /// Get full graph as JSON-serializable structure
     pub fn get_graph(&self) -> Result<DecisionGraph> {
-        let nodes = self.get_all_nodes()?;
-        let edges = self.get_all_edges()?;
-        let themes = self.get_all_themes().unwrap_or_default();
-        let node_themes = self.get_all_node_themes().unwrap_or_default();
-        let documents = self.get_node_documents(None, false).unwrap_or_default();
-        Ok(DecisionGraph {
-            nodes,
-            edges,
-            config: None,
-            themes,
-            node_themes,
-            documents,
-        })
+        self.get_graph_with_config(None)
     }
 
     /// Get full graph with config included (for export)
@@ -3294,6 +3302,102 @@ mod tests {
         assert_eq!(json.get("prompt").unwrap(), "User prompt");
         assert_eq!(json.get("branch").unwrap(), "main");
         assert!(json.get("files").unwrap().as_array().is_some());
+    }
+
+    // === DecisionNode Metadata Accessor Tests ===
+
+    fn node_with_metadata(metadata_json: Option<&str>) -> DecisionNode {
+        DecisionNode {
+            id: 1,
+            change_id: "test-change-id".to_string(),
+            node_type: "goal".to_string(),
+            title: "Test node".to_string(),
+            description: None,
+            status: "active".to_string(),
+            created_at: "2025-01-01T00:00:00Z".to_string(),
+            updated_at: "2025-01-01T00:00:00Z".to_string(),
+            metadata_json: metadata_json.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn test_node_accessors_absent_metadata() {
+        let node = node_with_metadata(None);
+        assert!(node.metadata().is_none());
+        assert_eq!(node.branch(), None);
+        assert_eq!(node.confidence(), None);
+        assert_eq!(node.commit(), None);
+        assert_eq!(node.prompt(), None);
+    }
+
+    #[test]
+    fn test_node_accessors_malformed_metadata() {
+        let node = node_with_metadata(Some("not json"));
+        assert!(node.metadata().is_none());
+        assert_eq!(node.branch(), None);
+        assert_eq!(node.confidence(), None);
+        assert_eq!(node.commit(), None);
+        assert_eq!(node.prompt(), None);
+    }
+
+    #[test]
+    fn test_node_accessors_missing_fields() {
+        let node = node_with_metadata(Some(r#"{"files":["a.rs"]}"#));
+        assert!(node.metadata().is_some());
+        assert_eq!(node.branch(), None);
+        assert_eq!(node.confidence(), None);
+        assert_eq!(node.commit(), None);
+        assert_eq!(node.prompt(), None);
+    }
+
+    #[test]
+    fn test_node_branch_accessor() {
+        let node = node_with_metadata(Some(r#"{"branch":"feature-x"}"#));
+        assert_eq!(node.branch(), Some("feature-x".to_string()));
+    }
+
+    #[test]
+    fn test_node_confidence_accessor() {
+        let node = node_with_metadata(Some(r#"{"confidence":85}"#));
+        assert_eq!(node.confidence(), Some(85));
+    }
+
+    #[test]
+    fn test_node_confidence_accessor_clamps_to_100() {
+        // Matches build_metadata_json's clamp behavior
+        let node = node_with_metadata(Some(r#"{"confidence":150}"#));
+        assert_eq!(node.confidence(), Some(100));
+    }
+
+    #[test]
+    fn test_node_confidence_accessor_non_numeric() {
+        let node = node_with_metadata(Some(r#"{"confidence":"high"}"#));
+        assert_eq!(node.confidence(), None);
+    }
+
+    #[test]
+    fn test_node_commit_accessor() {
+        let node = node_with_metadata(Some(r#"{"commit":"abc1234"}"#));
+        assert_eq!(node.commit(), Some("abc1234".to_string()));
+    }
+
+    #[test]
+    fn test_node_prompt_accessor() {
+        let node = node_with_metadata(Some(r#"{"prompt":"User asked: do X"}"#));
+        assert_eq!(node.prompt(), Some("User asked: do X".to_string()));
+    }
+
+    #[test]
+    fn test_node_metadata_accessor_full() {
+        let node = node_with_metadata(Some(
+            r#"{"confidence":90,"commit":"def456","prompt":"P","branch":"main"}"#,
+        ));
+        let meta = node.metadata().unwrap();
+        assert_eq!(meta.get("confidence").unwrap(), 90);
+        assert_eq!(node.branch(), Some("main".to_string()));
+        assert_eq!(node.confidence(), Some(90));
+        assert_eq!(node.commit(), Some("def456".to_string()));
+        assert_eq!(node.prompt(), Some("P".to_string()));
     }
 
     // === DecisionSchema Tests ===

--- a/src/export.rs
+++ b/src/export.rs
@@ -3,6 +3,7 @@
 //! Provides DOT graph export and PR writeup generation.
 
 use crate::db::{DecisionEdge, DecisionGraph, DecisionNode};
+use crate::util::truncate;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 
@@ -107,17 +108,6 @@ fn escape_dot(s: &str) -> String {
         .replace('\n', "\\n")
 }
 
-/// Truncate a string to max length (Unicode-safe)
-fn truncate(s: &str, max_len: usize) -> String {
-    if s.chars().count() <= max_len {
-        s.to_string()
-    } else {
-        let char_len = max_len.saturating_sub(3);
-        let truncated: String = s.chars().take(char_len).collect();
-        format!("{}...", truncated)
-    }
-}
-
 /// Extract confidence from metadata_json
 fn extract_confidence(metadata: &Option<String>) -> Option<u8> {
     metadata.as_ref().and_then(|m| {
@@ -125,18 +115,6 @@ fn extract_confidence(metadata: &Option<String>) -> Option<u8> {
             .ok()
             .and_then(|v| v.get("confidence").and_then(|c| c.as_u64()))
             .map(|c| c as u8)
-    })
-}
-
-/// Extract commit hash from metadata_json
-fn extract_commit(metadata: &Option<String>) -> Option<String> {
-    metadata.as_ref().and_then(|m| {
-        serde_json::from_str::<serde_json::Value>(m)
-            .ok()
-            .and_then(|v| {
-                v.get("commit")
-                    .and_then(|c| c.as_str().map(|s| s.to_string()))
-            })
     })
 }
 
@@ -441,10 +419,10 @@ pub fn generate_pr_writeup(graph: &DecisionGraph, config: &WriteupConfig) -> Str
         wln!(writeup, "## Implementation\n");
 
         for action in &actions {
-            let commit = extract_commit(&action.metadata_json);
+            let commit = action.commit();
             let commit_badge = commit
                 .as_ref()
-                .map(|c| format!(" `{}`", &c[..7.min(c.len())]))
+                .map(|c| format!(" `{}`", c.chars().take(7).collect::<String>()))
                 .unwrap_or_default();
 
             wln!(writeup, "- {}{}", action.title, commit_badge);
@@ -681,8 +659,23 @@ mod tests {
 
     #[test]
     fn test_extract_commit() {
-        let meta = Some(r#"{"commit":"abc1234"}"#.to_string());
-        assert_eq!(extract_commit(&meta), Some("abc1234".to_string()));
+        // Commit extraction now uses the DecisionNode::commit accessor
+        let node = node_with_metadata(Some(r#"{"commit":"abc1234"}"#.to_string()));
+        assert_eq!(node.commit(), Some("abc1234".to_string()));
+    }
+
+    fn node_with_metadata(metadata_json: Option<String>) -> DecisionNode {
+        DecisionNode {
+            id: 1,
+            change_id: "test-change-id".to_string(),
+            node_type: "action".to_string(),
+            title: "Test".to_string(),
+            description: None,
+            status: "pending".to_string(),
+            created_at: "2025-01-01T00:00:00Z".to_string(),
+            updated_at: "2025-01-01T00:00:00Z".to_string(),
+            metadata_json,
+        }
     }
 
     // === Additional Helper Function Tests ===
@@ -835,8 +828,8 @@ mod tests {
 
     #[test]
     fn test_extract_commit_invalid_json() {
-        let meta = Some("not json".to_string());
-        assert_eq!(extract_commit(&meta), None);
+        let node = node_with_metadata(Some("not json".to_string()));
+        assert_eq!(node.commit(), None);
     }
 
     // === Writeup Config Tests ===

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub mod pulse;
 pub mod roadmap;
 pub mod schema;
 pub mod serve;
+pub mod util;
 
 pub use config::Config;
 pub use db::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use deciduous::github::{ensure_roadmap_label, GitHubClient};
 use deciduous::roadmap::{
     generate_issue_body, parse_roadmap, write_roadmap_with_metadata, RoadmapSection,
 };
+use deciduous::util::truncate;
 use deciduous::{
     filter_graph_by_ids,
     generate_edge_id,
@@ -840,6 +841,25 @@ enum TagAction {
     },
 }
 
+/// Emit sync events if multi-user sync is initialized (.deciduous/sync exists).
+///
+/// The closure receives the current author and returns the events to append.
+/// Each append failure prints a warning but does not abort.
+fn emit_sync_events(build: impl FnOnce(String) -> Vec<Event>) {
+    let sync_dir = PathBuf::from(".deciduous/sync");
+    if !sync_dir.exists() {
+        return;
+    }
+    let author = get_current_author();
+    if let Ok(event_log) = EventLog::new(&PathBuf::from(".deciduous"), author.clone()) {
+        for event in build(author) {
+            if let Err(e) = event_log.append(event) {
+                eprintln!("{} Sync event: {}", "Warning:".yellow(), e);
+            }
+        }
+    }
+}
+
 fn main() {
     let args = Args::parse();
 
@@ -1131,29 +1151,22 @@ fn main() {
                     );
 
                     // Auto-emit event if sync is initialized
-                    let sync_dir = PathBuf::from(".deciduous/sync");
-                    if sync_dir.exists() {
+                    emit_sync_events(|author| {
                         if let Ok(Some(node)) = db.get_node(id) {
-                            let author = get_current_author();
-                            if let Ok(event_log) =
-                                EventLog::new(&PathBuf::from(".deciduous"), author.clone())
-                            {
-                                let event = Event::AddNode {
-                                    change_id: node.change_id.clone(),
-                                    node_type: node.node_type.clone(),
-                                    title: node.title.clone(),
-                                    description: node.description.clone(),
-                                    status: node.status.clone(),
-                                    metadata_json: node.metadata_json.clone(),
-                                    timestamp: chrono::Utc::now(),
-                                    author,
-                                };
-                                if let Err(e) = event_log.append(event) {
-                                    eprintln!("{} Sync event: {}", "Warning:".yellow(), e);
-                                }
-                            }
+                            vec![Event::AddNode {
+                                change_id: node.change_id.clone(),
+                                node_type: node.node_type.clone(),
+                                title: node.title.clone(),
+                                description: node.description.clone(),
+                                status: node.status.clone(),
+                                metadata_json: node.metadata_json.clone(),
+                                timestamp: chrono::Utc::now(),
+                                author,
+                            }]
+                        } else {
+                            Vec::new()
                         }
-                    }
+                    });
                 }
                 Err(e) => {
                     eprintln!("{} {}", "Error:".red(), e);
@@ -1179,36 +1192,29 @@ fn main() {
                 );
 
                 // Auto-emit event if sync is initialized
-                let sync_dir = PathBuf::from(".deciduous/sync");
-                if sync_dir.exists() {
+                emit_sync_events(|author| {
                     // Get change_ids for the nodes
                     let from_node = db.get_node(from).ok().flatten();
                     let to_node = db.get_node(to).ok().flatten();
 
                     if let (Some(from_n), Some(to_n)) = (from_node, to_node) {
-                        let author = get_current_author();
-                        if let Ok(event_log) =
-                            EventLog::new(&PathBuf::from(".deciduous"), author.clone())
-                        {
-                            let event = Event::AddEdge {
-                                edge_id: generate_edge_id(
-                                    &from_n.change_id,
-                                    &to_n.change_id,
-                                    &edge_type,
-                                ),
-                                from_change_id: from_n.change_id.clone(),
-                                to_change_id: to_n.change_id.clone(),
-                                edge_type: edge_type.clone(),
-                                rationale: rationale.clone(),
-                                timestamp: chrono::Utc::now(),
-                                author,
-                            };
-                            if let Err(e) = event_log.append(event) {
-                                eprintln!("{} Sync event: {}", "Warning:".yellow(), e);
-                            }
-                        }
+                        vec![Event::AddEdge {
+                            edge_id: generate_edge_id(
+                                &from_n.change_id,
+                                &to_n.change_id,
+                                &edge_type,
+                            ),
+                            from_change_id: from_n.change_id.clone(),
+                            to_change_id: to_n.change_id.clone(),
+                            edge_type: edge_type.clone(),
+                            rationale: rationale.clone(),
+                            timestamp: chrono::Utc::now(),
+                            author,
+                        }]
+                    } else {
+                        Vec::new()
                     }
-                }
+                });
             }
             Err(e) => {
                 eprintln!("{} {}", "Error:".red(), e);
@@ -1229,39 +1235,32 @@ fn main() {
                     println!("{} edge ({} -> {})", "Removed".red(), from, to);
 
                     // Auto-emit event if sync is initialized
-                    let sync_dir = PathBuf::from(".deciduous/sync");
-                    if sync_dir.exists() {
+                    emit_sync_events(|author| {
+                        let mut events = Vec::new();
                         if let (Some(from_n), Some(to_n)) = (from_node, to_node) {
-                            let author = get_current_author();
-                            if let Ok(event_log) =
-                                EventLog::new(&PathBuf::from(".deciduous"), author.clone())
-                            {
-                                // Emit one DeleteEdge per deleted edge, using each
-                                // edge's real type so the edge_id matches the one
-                                // emitted when the edge was created
-                                let mut emitted_ids: Vec<String> = Vec::new();
-                                for edge in &deleted_edges {
-                                    let edge_id = generate_edge_id(
-                                        &from_n.change_id,
-                                        &to_n.change_id,
-                                        &edge.edge_type,
-                                    );
-                                    if emitted_ids.contains(&edge_id) {
-                                        continue;
-                                    }
-                                    emitted_ids.push(edge_id.clone());
-                                    let event = Event::DeleteEdge {
-                                        edge_id,
-                                        timestamp: chrono::Utc::now(),
-                                        author: author.clone(),
-                                    };
-                                    if let Err(e) = event_log.append(event) {
-                                        eprintln!("{} Sync event: {}", "Warning:".yellow(), e);
-                                    }
+                            // Emit one DeleteEdge per deleted edge, using each
+                            // edge's real type so the edge_id matches the one
+                            // emitted when the edge was created
+                            let mut emitted_ids: Vec<String> = Vec::new();
+                            for edge in &deleted_edges {
+                                let edge_id = generate_edge_id(
+                                    &from_n.change_id,
+                                    &to_n.change_id,
+                                    &edge.edge_type,
+                                );
+                                if emitted_ids.contains(&edge_id) {
+                                    continue;
                                 }
+                                emitted_ids.push(edge_id.clone());
+                                events.push(Event::DeleteEdge {
+                                    edge_id,
+                                    timestamp: chrono::Utc::now(),
+                                    author: author.clone(),
+                                });
                             }
                         }
-                    }
+                        events
+                    });
                 }
                 Err(e) => {
                     eprintln!("{} {}", "Error:".red(), e);
@@ -1298,24 +1297,17 @@ fn main() {
                         );
 
                         // Auto-emit event if sync is initialized
-                        let sync_dir = PathBuf::from(".deciduous/sync");
-                        if sync_dir.exists() {
+                        emit_sync_events(|author| {
                             if let Some(node) = node_info {
-                                let author = get_current_author();
-                                if let Ok(event_log) =
-                                    EventLog::new(&PathBuf::from(".deciduous"), author.clone())
-                                {
-                                    let event = Event::DeleteNode {
-                                        change_id: node.change_id.clone(),
-                                        timestamp: chrono::Utc::now(),
-                                        author,
-                                    };
-                                    if let Err(e) = event_log.append(event) {
-                                        eprintln!("{} Sync event: {}", "Warning:".yellow(), e);
-                                    }
-                                }
+                                vec![Event::DeleteNode {
+                                    change_id: node.change_id.clone(),
+                                    timestamp: chrono::Utc::now(),
+                                    author,
+                                }]
+                            } else {
+                                Vec::new()
                             }
-                        }
+                        });
                     }
                 }
                 Err(e) => {
@@ -1330,28 +1322,21 @@ fn main() {
                 println!("{} node {} status to '{}'", "Updated".green(), id, status);
 
                 // Auto-emit event if sync is initialized
-                let sync_dir = PathBuf::from(".deciduous/sync");
-                if sync_dir.exists() {
+                emit_sync_events(|author| {
                     if let Ok(Some(node)) = db.get_node(id) {
-                        let author = get_current_author();
-                        if let Ok(event_log) =
-                            EventLog::new(&PathBuf::from(".deciduous"), author.clone())
-                        {
-                            let event = Event::UpdateNode {
-                                change_id: node.change_id.clone(),
-                                title: None,
-                                description: None,
-                                status: Some(status.clone()),
-                                metadata_json: None,
-                                timestamp: chrono::Utc::now(),
-                                author,
-                            };
-                            if let Err(e) = event_log.append(event) {
-                                eprintln!("{} Sync event: {}", "Warning:".yellow(), e);
-                            }
-                        }
+                        vec![Event::UpdateNode {
+                            change_id: node.change_id.clone(),
+                            title: None,
+                            description: None,
+                            status: Some(status.clone()),
+                            metadata_json: None,
+                            timestamp: chrono::Utc::now(),
+                            author,
+                        }]
+                    } else {
+                        Vec::new()
                     }
-                }
+                });
             }
             Err(e) => {
                 eprintln!("{} {}", "Error:".red(), e);
@@ -1425,16 +1410,7 @@ fn main() {
                         .filter(|n| {
                             // Filter by branch if specified
                             let branch_match = match &branch {
-                                Some(b) => n.metadata_json.as_ref().is_some_and(|meta| {
-                                    serde_json::from_str::<serde_json::Value>(meta)
-                                        .ok()
-                                        .and_then(|v| {
-                                            v.get("branch")
-                                                .and_then(|br| br.as_str())
-                                                .map(|s| s.to_string())
-                                        })
-                                        .is_some_and(|node_branch| node_branch == *b)
-                                }),
+                                Some(b) => n.branch().is_some_and(|node_branch| node_branch == *b),
                                 None => true,
                             };
                             // Filter by type if specified
@@ -1581,46 +1557,43 @@ fn main() {
                         println!("{}: {}", "Updated".bold(), node.updated_at);
 
                         // Parse metadata
-                        if let Some(ref meta_str) = node.metadata_json {
-                            if let Ok(meta) = serde_json::from_str::<serde_json::Value>(meta_str) {
+                        if let Some(meta) = node.metadata() {
+                            println!();
+                            println!("{}", "Metadata".bold().underline());
+
+                            if let Some(conf) = meta.get("confidence").and_then(|v| v.as_i64()) {
+                                let conf_colored = if conf >= 80 {
+                                    format!("{}%", conf).green()
+                                } else if conf >= 50 {
+                                    format!("{}%", conf).yellow()
+                                } else {
+                                    format!("{}%", conf).red()
+                                };
+                                println!("  {}: {}", "Confidence".bold(), conf_colored);
+                            }
+
+                            if let Some(branch) = meta.get("branch").and_then(|v| v.as_str()) {
+                                println!("  {}: {}", "Branch".bold(), branch.cyan());
+                            }
+
+                            if let Some(commit) = meta.get("commit").and_then(|v| v.as_str()) {
+                                println!("  {}: {}", "Commit".bold(), commit.yellow());
+                            }
+
+                            if let Some(files) = meta.get("files").and_then(|v| v.as_array()) {
+                                let file_list: Vec<&str> =
+                                    files.iter().filter_map(|f| f.as_str()).collect();
+                                if !file_list.is_empty() {
+                                    println!("  {}: {}", "Files".bold(), file_list.join(", "));
+                                }
+                            }
+
+                            if let Some(prompt) = meta.get("prompt").and_then(|v| v.as_str()) {
                                 println!();
-                                println!("{}", "Metadata".bold().underline());
-
-                                if let Some(conf) = meta.get("confidence").and_then(|v| v.as_i64())
-                                {
-                                    let conf_colored = if conf >= 80 {
-                                        format!("{}%", conf).green()
-                                    } else if conf >= 50 {
-                                        format!("{}%", conf).yellow()
-                                    } else {
-                                        format!("{}%", conf).red()
-                                    };
-                                    println!("  {}: {}", "Confidence".bold(), conf_colored);
-                                }
-
-                                if let Some(branch) = meta.get("branch").and_then(|v| v.as_str()) {
-                                    println!("  {}: {}", "Branch".bold(), branch.cyan());
-                                }
-
-                                if let Some(commit) = meta.get("commit").and_then(|v| v.as_str()) {
-                                    println!("  {}: {}", "Commit".bold(), commit.yellow());
-                                }
-
-                                if let Some(files) = meta.get("files").and_then(|v| v.as_array()) {
-                                    let file_list: Vec<&str> =
-                                        files.iter().filter_map(|f| f.as_str()).collect();
-                                    if !file_list.is_empty() {
-                                        println!("  {}: {}", "Files".bold(), file_list.join(", "));
-                                    }
-                                }
-
-                                if let Some(prompt) = meta.get("prompt").and_then(|v| v.as_str()) {
-                                    println!();
-                                    println!("{}", "Prompt".bold().underline());
-                                    // Word-wrap long prompts
-                                    for line in prompt.lines() {
-                                        println!("  {}", line.italic());
-                                    }
+                                println!("{}", "Prompt".bold().underline());
+                                // Word-wrap long prompts
+                                for line in prompt.lines() {
+                                    println!("  {}", line.italic());
                                 }
                             }
                         }
@@ -3220,32 +3193,14 @@ fn main() {
                 .filter(|n| n.node_type == "action" || n.node_type == "outcome")
                 .filter(|n| {
                     // Check if already has commit
-                    !n.metadata_json
-                        .as_ref()
-                        .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
-                        .and_then(|v| {
-                            v.get("commit")
-                                .and_then(|c| c.as_str())
-                                .map(|s| !s.is_empty())
-                        })
-                        .unwrap_or(false)
+                    !n.commit().is_some_and(|s| !s.is_empty())
                 })
                 .collect();
 
             let with_commits = nodes
                 .iter()
                 .filter(|n| n.node_type == "action" || n.node_type == "outcome")
-                .filter(|n| {
-                    n.metadata_json
-                        .as_ref()
-                        .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
-                        .and_then(|v| {
-                            v.get("commit")
-                                .and_then(|c| c.as_str())
-                                .map(|s| !s.is_empty())
-                        })
-                        .unwrap_or(false)
-                })
+                .filter(|n| n.commit().is_some_and(|s| !s.is_empty()))
                 .count();
 
             println!(
@@ -4566,16 +4521,6 @@ fn parse_backdate(d: &str) -> String {
     d.to_string()
 }
 
-fn truncate(s: &str, max_len: usize) -> String {
-    if s.chars().count() <= max_len {
-        s.to_string()
-    } else {
-        let char_len = max_len.saturating_sub(3);
-        let truncated: String = s.chars().take(char_len).collect();
-        format!("{}...", truncated)
-    }
-}
-
 // =============================================================================
 // Audit command helpers
 // =============================================================================
@@ -4672,13 +4617,9 @@ struct GitCommit {
 fn extract_commit_hashes(nodes: &[deciduous::DecisionNode]) -> Vec<String> {
     let mut hashes = std::collections::HashSet::new();
     for node in nodes {
-        if let Some(ref meta_json) = node.metadata_json {
-            if let Ok(meta) = serde_json::from_str::<serde_json::Value>(meta_json) {
-                if let Some(commit) = meta.get("commit").and_then(|c| c.as_str()) {
-                    if !commit.is_empty() {
-                        hashes.insert(commit.to_string());
-                    }
-                }
+        if let Some(commit) = node.commit() {
+            if !commit.is_empty() {
+                hashes.insert(commit);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4602,17 +4602,6 @@ fn keyword_match_score(node_title: &str, commit_message: &str) -> f64 {
 // Git history export helpers
 // =============================================================================
 
-/// Git commit info for timeline view (matches web/src/types/graph.ts GitCommit)
-#[derive(serde::Serialize)]
-struct GitCommit {
-    hash: String,
-    short_hash: String,
-    author: String,
-    date: String,
-    message: String,
-    files_changed: Option<u32>,
-}
-
 /// Extract all unique commit hashes from nodes' metadata_json
 fn extract_commit_hashes(nodes: &[deciduous::DecisionNode]) -> Vec<String> {
     let mut hashes = std::collections::HashSet::new();
@@ -4626,63 +4615,16 @@ fn extract_commit_hashes(nodes: &[deciduous::DecisionNode]) -> Vec<String> {
     hashes.into_iter().collect()
 }
 
-/// Get commit info from git for a given hash
-fn get_git_commit_info(hash: &str) -> Option<GitCommit> {
-    // Get commit info: hash, author, date (ISO), full message body
-    // Use %x00 (null byte) as separator since message can have newlines
-    let output = ProcessCommand::new("git")
-        .args(["log", "-1", "--format=%H%x00%an%x00%aI%x00%B", hash])
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let parts: Vec<&str> = stdout.trim().split('\x00').collect();
-    if parts.len() < 4 {
-        return None;
-    }
-
-    // Clean up the message - trim whitespace
-    let message = parts[3].trim().to_string();
-
-    // Get files changed count
-    let files_output = ProcessCommand::new("git")
-        .args(["diff-tree", "--no-commit-id", "--name-only", "-r", hash])
-        .output()
-        .ok();
-
-    let files_changed = files_output.and_then(|o| {
-        if o.status.success() {
-            let count = String::from_utf8_lossy(&o.stdout).trim().lines().count();
-            Some(count as u32)
-        } else {
-            None
-        }
-    });
-
-    Some(GitCommit {
-        hash: parts[0].to_string(),
-        short_hash: parts[0].chars().take(7).collect(),
-        author: parts[1].to_string(),
-        date: parts[2].to_string(),
-        message,
-        files_changed,
-    })
-}
-
 /// Generate git-history.json for all commits linked to nodes
 fn export_git_history(
     nodes: &[deciduous::DecisionNode],
     output_dir: &std::path::Path,
 ) -> Result<usize, Box<dyn std::error::Error>> {
     let hashes = extract_commit_hashes(nodes);
-    let mut commits: Vec<GitCommit> = Vec::new();
+    let mut commits: Vec<deciduous::util::GitCommit> = Vec::new();
 
     for hash in &hashes {
-        if let Some(commit) = get_git_commit_info(hash) {
+        if let Some(commit) = deciduous::util::get_git_commit_info(hash, None) {
             commits.push(commit);
         }
     }

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -144,13 +144,11 @@ fn node_to_json(node: &crate::db::DecisionNode) -> Value {
     }
 
     // Unpack metadata_json into top-level fields for easier consumption
-    if let Some(ref meta_str) = node.metadata_json {
-        if let Ok(meta) = serde_json::from_str::<Value>(meta_str) {
-            if let Some(obj_mut) = obj.as_object_mut() {
-                if let Some(m) = meta.as_object() {
-                    for (k, v) in m {
-                        obj_mut.insert(k.clone(), v.clone());
-                    }
+    if let Some(meta) = node.metadata() {
+        if let Some(obj_mut) = obj.as_object_mut() {
+            if let Some(m) = meta.as_object() {
+                for (k, v) in m {
+                    obj_mut.insert(k.clone(), v.clone());
                 }
             }
         }
@@ -315,15 +313,7 @@ fn handle_list_nodes(db: &Database, args: &Value) -> HandlerResult {
         .filter(|n| {
             // Branch filter: check metadata_json for branch field
             if let Some(branch) = branch_filter {
-                if let Some(ref meta_str) = n.metadata_json {
-                    if let Ok(meta) = serde_json::from_str::<Value>(meta_str) {
-                        if meta.get("branch").and_then(Value::as_str) != Some(branch) {
-                            return false;
-                        }
-                    } else {
-                        return false;
-                    }
-                } else {
+                if n.branch().as_deref() != Some(branch) {
                     return false;
                 }
             }
@@ -455,19 +445,8 @@ fn handle_search_nodes(db: &Database, args: &Value) -> HandlerResult {
                 .map(|d| d.to_lowercase().contains(&query_lower))
                 .unwrap_or(false);
             let prompt_match = n
-                .metadata_json
-                .as_ref()
-                .map(|m| {
-                    serde_json::from_str::<Value>(m)
-                        .ok()
-                        .and_then(|v| {
-                            v.get("prompt")
-                                .and_then(Value::as_str)
-                                .map(|p| p.to_lowercase().contains(&query_lower))
-                        })
-                        .unwrap_or(false)
-                })
-                .unwrap_or(false);
+                .prompt()
+                .is_some_and(|p| p.to_lowercase().contains(&query_lower));
 
             let text_match = title_match || desc_match || prompt_match;
             if !text_match {
@@ -483,15 +462,7 @@ fn handle_search_nodes(db: &Database, args: &Value) -> HandlerResult {
 
             // Optional branch filter
             if let Some(branch) = branch_filter {
-                if let Some(ref meta_str) = n.metadata_json {
-                    if let Ok(meta) = serde_json::from_str::<Value>(meta_str) {
-                        if meta.get("branch").and_then(Value::as_str) != Some(branch) {
-                            return false;
-                        }
-                    } else {
-                        return false;
-                    }
-                } else {
+                if n.branch().as_deref() != Some(branch) {
                     return false;
                 }
             }

--- a/src/mcp/query.rs
+++ b/src/mcp/query.rs
@@ -503,20 +503,18 @@ fn node_summary_json(node: &DecisionNode) -> Value {
     }
 
     // Unpack key metadata fields
-    if let Some(ref meta_str) = node.metadata_json {
-        if let Ok(meta) = serde_json::from_str::<Value>(meta_str) {
-            if let Some(c) = meta.get("confidence").and_then(Value::as_u64) {
-                j["confidence"] = json!(c);
-            }
-            if let Some(b) = meta.get("branch").and_then(Value::as_str) {
-                j["branch"] = json!(b);
-            }
-            if let Some(commit) = meta.get("commit").and_then(Value::as_str) {
-                j["commit"] = json!(commit);
-            }
-            if let Some(prompt) = meta.get("prompt").and_then(Value::as_str) {
-                j["prompt"] = json!(prompt);
-            }
+    if let Some(meta) = node.metadata() {
+        if let Some(c) = meta.get("confidence").and_then(Value::as_u64) {
+            j["confidence"] = json!(c);
+        }
+        if let Some(b) = meta.get("branch").and_then(Value::as_str) {
+            j["branch"] = json!(b);
+        }
+        if let Some(commit) = meta.get("commit").and_then(Value::as_str) {
+            j["commit"] = json!(commit);
+        }
+        if let Some(prompt) = meta.get("prompt").and_then(Value::as_str) {
+            j["prompt"] = json!(prompt);
         }
     }
 
@@ -537,11 +535,7 @@ fn edge_summary_json(edge: &DecisionEdge) -> Value {
 }
 
 fn node_has_branch(node: &DecisionNode, branch: &str) -> bool {
-    node.metadata_json
-        .as_ref()
-        .and_then(|m| serde_json::from_str::<Value>(m).ok())
-        .and_then(|v| v.get("branch").and_then(Value::as_str).map(|b| b == branch))
-        .unwrap_or(false)
+    node.branch().is_some_and(|b| b == branch)
 }
 
 fn build_adjacency_out(edges: &[DecisionEdge]) -> HashMap<i32, Vec<i32>> {

--- a/src/opencode.rs
+++ b/src/opencode.rs
@@ -2572,19 +2572,45 @@ fn ensure_core_infrastructure(project_root: &Path) -> Result<(), String> {
     Ok(())
 }
 
-/// Install OpenCode configuration and plugins
-pub fn install_opencode(project_root: &Path) -> Result<(), String> {
-    println!("\n{}", "Installing OpenCode integration...".cyan().bold());
-    println!("   Directory: {}\n", project_root.display());
+/// Command files written to .opencode/commands/ by install and update
+const OPENCODE_COMMANDS: &[(&str, &str)] = &[
+    ("work.md", COMMAND_WORK),
+    ("recover.md", COMMAND_RECOVER),
+    ("decision.md", COMMAND_DECISION),
+    ("build-test.md", COMMAND_BUILD_TEST),
+    ("serve-ui.md", COMMAND_SERVE_UI),
+    ("sync-graph.md", COMMAND_SYNC_GRAPH),
+    ("document.md", COMMAND_DOCUMENT),
+    ("sync.md", COMMAND_SYNC),
+    ("decision-graph.md", COMMAND_DECISION_GRAPH),
+];
 
-    // First, ensure core deciduous infrastructure exists
-    ensure_core_infrastructure(project_root)?;
+/// Skills written to .opencode/skills/<name>/SKILL.md by install and update
+const OPENCODE_SKILLS: &[(&str, &str)] = &[
+    ("pulse", SKILL_PULSE_OPENCODE),
+    ("narratives", SKILL_NARRATIVES_OPENCODE),
+    ("archaeology", SKILL_ARCHAEOLOGY_OPENCODE),
+];
 
-    // Migrate old singular dirs before creating anything
-    migrate_opencode_dirs(project_root)?;
+/// All plugin files, written unconditionally by update. Install gates the
+/// hook plugins on config instead (see `install_opencode`).
+const OPENCODE_PLUGINS: &[(&str, &str)] = &[
+    ("require-action-node.ts", PLUGIN_REQUIRE_ACTION_NODE),
+    ("post-commit-reminder.ts", PLUGIN_POST_COMMIT_REMINDER),
+    ("version-check.ts", PLUGIN_VERSION_CHECK),
+];
 
-    let config = Config::load();
-
+/// Write the OpenCode integration files shared by install and update:
+/// directories, plugins, commands, skills, agent, and tool.
+///
+/// `plugins` is the list of plugin files to write (install gates hook plugins
+/// behind config checks; update writes all of them). `verb` is the past-tense
+/// verb printed for each file ("Installed" or "Updated").
+fn write_opencode_integration_files(
+    project_root: &Path,
+    plugins: &[(&str, &str)],
+    verb: &str,
+) -> Result<(), String> {
     let opencode_dir = project_root.join(".opencode");
     let plugin_dir = opencode_dir.join("plugins");
     let command_dir = opencode_dir.join("commands");
@@ -2607,70 +2633,23 @@ pub fn install_opencode(project_root: &Path) -> Result<(), String> {
         }
     }
 
-    // Install plugins (hooks)
-    if config.hooks.enabled {
-        for hook in &config.hooks.pre_tool_use {
-            if hook.enabled && hook.name == "require-action-node" {
-                let plugin_path = plugin_dir.join("require-action-node.ts");
-                fs::write(&plugin_path, PLUGIN_REQUIRE_ACTION_NODE)
-                    .map_err(|e| format!("Could not write plugin: {}", e))?;
-                println!(
-                    "   {} .opencode/plugins/require-action-node.ts",
-                    "Installed".green()
-                );
-            }
-        }
-
-        for hook in &config.hooks.post_tool_use {
-            if hook.enabled && hook.name == "post-commit-reminder" {
-                let plugin_path = plugin_dir.join("post-commit-reminder.ts");
-                fs::write(&plugin_path, PLUGIN_POST_COMMIT_REMINDER)
-                    .map_err(|e| format!("Could not write plugin: {}", e))?;
-                println!(
-                    "   {} .opencode/plugins/post-commit-reminder.ts",
-                    "Installed".green()
-                );
-            }
-        }
-
-        // Always install version-check plugin (opt-in via config.toml)
-        let version_check_path = plugin_dir.join("version-check.ts");
-        fs::write(&version_check_path, PLUGIN_VERSION_CHECK)
-            .map_err(|e| format!("Could not write plugin: {}", e))?;
-        println!(
-            "   {} .opencode/plugins/version-check.ts",
-            "Installed".green()
-        );
+    // Write plugins
+    for (name, content) in plugins {
+        let plugin_path = plugin_dir.join(name);
+        fs::write(&plugin_path, content).map_err(|e| format!("Could not write plugin: {}", e))?;
+        println!("   {} .opencode/plugins/{}", verb.green(), name);
     }
 
-    // Install commands
-    let commands = [
-        ("work.md", COMMAND_WORK),
-        ("recover.md", COMMAND_RECOVER),
-        ("decision.md", COMMAND_DECISION),
-        ("build-test.md", COMMAND_BUILD_TEST),
-        ("serve-ui.md", COMMAND_SERVE_UI),
-        ("sync-graph.md", COMMAND_SYNC_GRAPH),
-        ("document.md", COMMAND_DOCUMENT),
-        ("sync.md", COMMAND_SYNC),
-        ("decision-graph.md", COMMAND_DECISION_GRAPH),
-    ];
-
-    for (name, content) in commands {
+    // Write commands
+    for (name, content) in OPENCODE_COMMANDS {
         let cmd_path = command_dir.join(name);
         fs::write(&cmd_path, content)
             .map_err(|e| format!("Could not write command {}: {}", name, e))?;
-        println!("   {} .opencode/commands/{}", "Installed".green(), name);
+        println!("   {} .opencode/commands/{}", verb.green(), name);
     }
 
-    // Install skills in proper directory structure (.opencode/skills/<name>/SKILL.md)
-    let skills = [
-        ("pulse", SKILL_PULSE_OPENCODE),
-        ("narratives", SKILL_NARRATIVES_OPENCODE),
-        ("archaeology", SKILL_ARCHAEOLOGY_OPENCODE),
-    ];
-
-    for (name, content) in skills {
+    // Write skills in proper directory structure (.opencode/skills/<name>/SKILL.md)
+    for (name, content) in OPENCODE_SKILLS {
         let skill_subdir = skill_dir.join(name);
         if !skill_subdir.exists() {
             fs::create_dir_all(&skill_subdir)
@@ -2679,22 +2658,56 @@ pub fn install_opencode(project_root: &Path) -> Result<(), String> {
         let skill_path = skill_subdir.join("SKILL.md");
         fs::write(&skill_path, content)
             .map_err(|e| format!("Could not write skill {}: {}", name, e))?;
-        println!(
-            "   {} .opencode/skills/{}/SKILL.md",
-            "Installed".green(),
-            name
-        );
+        println!("   {} .opencode/skills/{}/SKILL.md", verb.green(), name);
     }
 
-    // Install custom agent
+    // Write custom agent
     let agent_path = agent_dir.join("deciduous.md");
     fs::write(&agent_path, AGENT_DECIDUOUS).map_err(|e| format!("Could not write agent: {}", e))?;
-    println!("   {} .opencode/agents/deciduous.md", "Installed".green());
+    println!("   {} .opencode/agents/deciduous.md", verb.green());
 
-    // Install custom tool
+    // Write custom tool
     let tool_path = tool_dir.join("deciduous.ts");
     fs::write(&tool_path, TOOL_DECIDUOUS).map_err(|e| format!("Could not write tool: {}", e))?;
-    println!("   {} .opencode/tools/deciduous.ts", "Installed".green());
+    println!("   {} .opencode/tools/deciduous.ts", verb.green());
+
+    Ok(())
+}
+
+/// Install OpenCode configuration and plugins
+pub fn install_opencode(project_root: &Path) -> Result<(), String> {
+    println!("\n{}", "Installing OpenCode integration...".cyan().bold());
+    println!("   Directory: {}\n", project_root.display());
+
+    // First, ensure core deciduous infrastructure exists
+    ensure_core_infrastructure(project_root)?;
+
+    // Migrate old singular dirs before creating anything
+    migrate_opencode_dirs(project_root)?;
+
+    let config = Config::load();
+
+    // Install plugins (hooks) - gated on config, unlike update which writes all
+    let mut plugins: Vec<(&str, &str)> = Vec::new();
+    if config.hooks.enabled {
+        for hook in &config.hooks.pre_tool_use {
+            if hook.enabled && hook.name == "require-action-node" {
+                plugins.push(("require-action-node.ts", PLUGIN_REQUIRE_ACTION_NODE));
+            }
+        }
+
+        for hook in &config.hooks.post_tool_use {
+            if hook.enabled && hook.name == "post-commit-reminder" {
+                plugins.push(("post-commit-reminder.ts", PLUGIN_POST_COMMIT_REMINDER));
+            }
+        }
+
+        // Always install version-check plugin (opt-in via config.toml)
+        plugins.push(("version-check.ts", PLUGIN_VERSION_CHECK));
+    }
+
+    // Install directories, plugins, commands, skills, agent, and tool
+    write_opencode_integration_files(project_root, &plugins, "Installed")?;
 
     // Generate opencode.json config
     // Plugins are auto-loaded from .opencode/plugins/
@@ -2839,105 +2852,9 @@ pub fn update_opencode(project_root: &Path) -> Result<(), String> {
     // Migrate from old singular directory names to plural
     migrate_opencode_dirs(project_root)?;
 
-    let opencode_dir = project_root.join(".opencode");
-    let plugin_dir = opencode_dir.join("plugins");
-    let command_dir = opencode_dir.join("commands");
-    let skill_dir = opencode_dir.join("skills");
-    let agent_dir = opencode_dir.join("agents");
-    let tool_dir = opencode_dir.join("tools");
-
-    // Create directories if needed
-    for dir in [
-        &opencode_dir,
-        &plugin_dir,
-        &command_dir,
-        &skill_dir,
-        &agent_dir,
-        &tool_dir,
-    ] {
-        if !dir.exists() {
-            fs::create_dir_all(dir).map_err(|e| format!("Could not create {:?}: {}", dir, e))?;
-            println!("   {} {:?}", "Creating".green(), dir);
-        }
-    }
-
-    // Update plugins (overwrite)
-    let plugin_path = plugin_dir.join("require-action-node.ts");
-    fs::write(&plugin_path, PLUGIN_REQUIRE_ACTION_NODE)
-        .map_err(|e| format!("Could not write plugin: {}", e))?;
-    println!(
-        "   {} .opencode/plugins/require-action-node.ts",
-        "Updated".green()
-    );
-
-    let plugin_path = plugin_dir.join("post-commit-reminder.ts");
-    fs::write(&plugin_path, PLUGIN_POST_COMMIT_REMINDER)
-        .map_err(|e| format!("Could not write plugin: {}", e))?;
-    println!(
-        "   {} .opencode/plugins/post-commit-reminder.ts",
-        "Updated".green()
-    );
-
-    let plugin_path = plugin_dir.join("version-check.ts");
-    fs::write(&plugin_path, PLUGIN_VERSION_CHECK)
-        .map_err(|e| format!("Could not write plugin: {}", e))?;
-    println!(
-        "   {} .opencode/plugins/version-check.ts",
-        "Updated".green()
-    );
-
-    // Update commands (overwrite)
-    let commands = [
-        ("work.md", COMMAND_WORK),
-        ("recover.md", COMMAND_RECOVER),
-        ("decision.md", COMMAND_DECISION),
-        ("build-test.md", COMMAND_BUILD_TEST),
-        ("serve-ui.md", COMMAND_SERVE_UI),
-        ("sync-graph.md", COMMAND_SYNC_GRAPH),
-        ("document.md", COMMAND_DOCUMENT),
-        ("sync.md", COMMAND_SYNC),
-        ("decision-graph.md", COMMAND_DECISION_GRAPH),
-    ];
-
-    for (name, content) in commands {
-        let cmd_path = command_dir.join(name);
-        fs::write(&cmd_path, content)
-            .map_err(|e| format!("Could not write command {}: {}", name, e))?;
-        println!("   {} .opencode/commands/{}", "Updated".green(), name);
-    }
-
-    // Update skills in proper directory structure
-    let skills = [
-        ("pulse", SKILL_PULSE_OPENCODE),
-        ("narratives", SKILL_NARRATIVES_OPENCODE),
-        ("archaeology", SKILL_ARCHAEOLOGY_OPENCODE),
-    ];
-
-    for (name, content) in skills {
-        let skill_subdir = skill_dir.join(name);
-        if !skill_subdir.exists() {
-            fs::create_dir_all(&skill_subdir)
-                .map_err(|e| format!("Could not create {:?}: {}", skill_subdir, e))?;
-        }
-        let skill_path = skill_subdir.join("SKILL.md");
-        fs::write(&skill_path, content)
-            .map_err(|e| format!("Could not write skill {}: {}", name, e))?;
-        println!(
-            "   {} .opencode/skills/{}/SKILL.md",
-            "Updated".green(),
-            name
-        );
-    }
-
-    // Update agent (overwrite)
-    let agent_path = agent_dir.join("deciduous.md");
-    fs::write(&agent_path, AGENT_DECIDUOUS).map_err(|e| format!("Could not write agent: {}", e))?;
-    println!("   {} .opencode/agents/deciduous.md", "Updated".green());
-
-    // Update tool (overwrite)
-    let tool_path = tool_dir.join("deciduous.ts");
-    fs::write(&tool_path, TOOL_DECIDUOUS).map_err(|e| format!("Could not write tool: {}", e))?;
-    println!("   {} .opencode/tools/deciduous.ts", "Updated".green());
+    // Update directories, plugins, commands, skills, agent, and tool (overwrite).
+    // Unlike install, all plugins are written unconditionally.
+    write_opencode_integration_files(project_root, OPENCODE_PLUGINS, "Updated")?;
 
     // Note: We don't overwrite opencode.json or AGENTS.md as they may have user customizations
     println!(
@@ -3581,6 +3498,78 @@ mod tests {
         // Check config files
         assert!(project_root.join("opencode.json").exists());
         assert!(project_root.join("AGENTS.md").exists());
+    }
+
+    /// Recursively collect relative file paths and contents under `dir`
+    fn collect_files(
+        dir: &Path,
+        base: &Path,
+        out: &mut std::collections::BTreeMap<String, Vec<u8>>,
+    ) {
+        if let Ok(entries) = fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    collect_files(&path, base, out);
+                } else {
+                    let rel = path
+                        .strip_prefix(base)
+                        .unwrap()
+                        .to_string_lossy()
+                        .replace('\\', "/");
+                    out.insert(rel, fs::read(&path).unwrap());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_install_update_write_identical_files() {
+        // install_opencode and update_opencode must write byte-identical
+        // command/skill/agent/tool files. Plugins are excluded from the
+        // comparison because install gates them on config while update
+        // writes all of them unconditionally.
+        let install_tmp = TempDir::new().unwrap();
+        let update_tmp = TempDir::new().unwrap();
+
+        // install_opencode needs core infrastructure config
+        let deciduous_dir = install_tmp.path().join(".deciduous");
+        fs::create_dir_all(&deciduous_dir).unwrap();
+        fs::write(deciduous_dir.join("config.toml"), "[hooks]\nenabled = true").unwrap();
+
+        install_opencode(install_tmp.path()).unwrap();
+        update_opencode(update_tmp.path()).unwrap();
+
+        for subdir in ["commands", "skills", "agents", "tools"] {
+            let install_dir = install_tmp.path().join(".opencode").join(subdir);
+            let update_dir = update_tmp.path().join(".opencode").join(subdir);
+
+            let mut installed = std::collections::BTreeMap::new();
+            collect_files(&install_dir, &install_dir, &mut installed);
+            let mut updated = std::collections::BTreeMap::new();
+            collect_files(&update_dir, &update_dir, &mut updated);
+
+            assert!(
+                !installed.is_empty(),
+                "install wrote no files under .opencode/{}",
+                subdir
+            );
+            assert_eq!(
+                installed.keys().collect::<Vec<_>>(),
+                updated.keys().collect::<Vec<_>>(),
+                "install and update wrote different file sets under .opencode/{}",
+                subdir
+            );
+            for (name, content) in &installed {
+                assert_eq!(
+                    Some(content),
+                    updated.get(name),
+                    "install and update wrote different content for .opencode/{}/{}",
+                    subdir,
+                    name
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/pulse.rs
+++ b/src/pulse.rs
@@ -65,31 +65,14 @@ pub struct CoverageGap {
 }
 
 fn node_to_ref(node: &DecisionNode) -> NodeRef {
-    let confidence = node
-        .metadata_json
-        .as_ref()
-        .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
-        .and_then(|v| v.get("confidence").and_then(|c| c.as_u64()))
-        .map(|c| c.min(100) as u8);
     NodeRef {
         id: node.id,
         node_type: node.node_type.clone(),
         title: node.title.clone(),
         status: node.status.clone(),
-        confidence,
+        confidence: node.confidence(),
         created_at: node.created_at.clone(),
     }
-}
-
-fn get_branch(node: &DecisionNode) -> Option<String> {
-    node.metadata_json
-        .as_ref()
-        .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
-        .and_then(|v| {
-            v.get("branch")
-                .and_then(|b| b.as_str())
-                .map(|s| s.to_string())
-        })
 }
 
 /// Generate the full pulse report
@@ -105,7 +88,7 @@ pub fn generate_pulse(
     let nodes: Vec<&DecisionNode> = if let Some(br) = branch {
         all_nodes
             .iter()
-            .filter(|n| get_branch(n).as_deref() == Some(br))
+            .filter(|n| n.branch().as_deref() == Some(br))
             .collect()
     } else {
         all_nodes.iter().collect()

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -231,13 +231,9 @@ fn get_git_history() -> Vec<GitCommit> {
     // Extract unique commit hashes from node metadata
     let mut hashes = HashSet::new();
     for node in &nodes {
-        if let Some(ref meta_json) = node.metadata_json {
-            if let Ok(meta) = serde_json::from_str::<serde_json::Value>(meta_json) {
-                if let Some(commit) = meta.get("commit").and_then(|c| c.as_str()) {
-                    if !commit.is_empty() {
-                        hashes.insert(commit.to_string());
-                    }
-                }
+        if let Some(commit) = node.commit() {
+            if !commit.is_empty() {
+                hashes.insert(commit);
             }
         }
     }
@@ -690,14 +686,12 @@ IMPORTANT: If information is missing or incomplete, tell the user explicitly and
                         prompt.push_str(&format!("Description: {}\n", desc));
                     }
                     // Parse metadata for additional context
-                    if let Some(meta_str) = &node.metadata_json {
-                        if let Ok(meta) = serde_json::from_str::<serde_json::Value>(meta_str) {
-                            if let Some(branch) = meta.get("branch").and_then(|v| v.as_str()) {
-                                prompt.push_str(&format!("Branch: {}\n", branch));
-                            }
-                            if let Some(prompt_text) = meta.get("prompt").and_then(|v| v.as_str()) {
-                                prompt.push_str(&format!("Original prompt: {}\n", prompt_text));
-                            }
+                    if let Some(meta) = node.metadata() {
+                        if let Some(branch) = meta.get("branch").and_then(|v| v.as_str()) {
+                            prompt.push_str(&format!("Branch: {}\n", branch));
+                        }
+                        if let Some(prompt_text) = meta.get("prompt").and_then(|v| v.as_str()) {
+                            prompt.push_str(&format!("Original prompt: {}\n", prompt_text));
                         }
                     }
                     prompt.push('\n');

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -195,16 +195,7 @@ fn get_roadmap_items() -> Vec<RoadmapItem> {
 
 // === Git History Types and Functions ===
 
-/// Git commit info for timeline view (matches web/src/types/graph.ts GitCommit)
-#[derive(Serialize)]
-struct GitCommit {
-    hash: String,
-    short_hash: String,
-    author: String,
-    date: String,
-    message: String,
-    files_changed: Option<u32>,
-}
+use crate::util::{get_git_commit_info, GitCommit};
 
 /// Get git history for all commits linked to nodes
 fn get_git_history() -> Vec<GitCommit> {
@@ -346,63 +337,6 @@ fn find_git_repo_root() -> Option<std::path::PathBuf> {
         }
         dir = dir.parent()?;
     }
-}
-
-/// Get commit info from git for a given hash
-fn get_git_commit_info(hash: &str, repo_root: Option<&std::path::Path>) -> Option<GitCommit> {
-    use std::process::Command;
-
-    // Get commit info: hash, author, date (ISO), full message body
-    // Use %x00 (null byte) as separator since message can have newlines
-    let mut cmd = Command::new("git");
-    if let Some(root) = repo_root {
-        cmd.current_dir(root);
-    }
-    let output = cmd
-        .args(["log", "-1", "--format=%H%x00%an%x00%aI%x00%B", hash])
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let parts: Vec<&str> = stdout.trim().split('\x00').collect();
-    if parts.len() < 4 {
-        return None;
-    }
-
-    // Clean up the message - trim whitespace
-    let message = parts[3].trim().to_string();
-
-    // Get files changed count
-    let mut files_cmd = Command::new("git");
-    if let Some(root) = repo_root {
-        files_cmd.current_dir(root);
-    }
-    let files_output = files_cmd
-        .args(["diff-tree", "--no-commit-id", "--name-only", "-r", hash])
-        .output()
-        .ok();
-
-    let files_changed = files_output.and_then(|o| {
-        if o.status.success() {
-            let count = String::from_utf8_lossy(&o.stdout).trim().lines().count();
-            Some(count as u32)
-        } else {
-            None
-        }
-    });
-
-    Some(GitCommit {
-        hash: parts[0].to_string(),
-        short_hash: parts[0].chars().take(7).collect(),
-        author: parts[1].to_string(),
-        date: parts[2].to_string(),
-        message,
-        files_changed,
-    })
 }
 
 #[derive(serde::Deserialize)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,3 +10,74 @@ pub fn truncate(s: &str, max_len: usize) -> String {
         format!("{}...", truncated)
     }
 }
+
+/// Git commit info for timeline view (matches web/src/types/graph.ts GitCommit)
+#[derive(serde::Serialize)]
+pub struct GitCommit {
+    pub hash: String,
+    pub short_hash: String,
+    pub author: String,
+    pub date: String,
+    pub message: String,
+    pub files_changed: Option<u32>,
+}
+
+/// Get commit info from git for a given hash.
+///
+/// If `repo_root` is provided, git commands run in that directory;
+/// otherwise they run in the current working directory.
+pub fn get_git_commit_info(hash: &str, repo_root: Option<&std::path::Path>) -> Option<GitCommit> {
+    use std::process::Command;
+
+    // Get commit info: hash, author, date (ISO), full message body
+    // Use %x00 (null byte) as separator since message can have newlines
+    let mut cmd = Command::new("git");
+    if let Some(root) = repo_root {
+        cmd.current_dir(root);
+    }
+    let output = cmd
+        .args(["log", "-1", "--format=%H%x00%an%x00%aI%x00%B", hash])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parts: Vec<&str> = stdout.trim().split('\x00').collect();
+    if parts.len() < 4 {
+        return None;
+    }
+
+    // Clean up the message - trim whitespace
+    let message = parts[3].trim().to_string();
+
+    // Get files changed count
+    let mut files_cmd = Command::new("git");
+    if let Some(root) = repo_root {
+        files_cmd.current_dir(root);
+    }
+    let files_output = files_cmd
+        .args(["diff-tree", "--no-commit-id", "--name-only", "-r", hash])
+        .output()
+        .ok();
+
+    let files_changed = files_output.and_then(|o| {
+        if o.status.success() {
+            let count = String::from_utf8_lossy(&o.stdout).trim().lines().count();
+            Some(count as u32)
+        } else {
+            None
+        }
+    });
+
+    Some(GitCommit {
+        hash: parts[0].to_string(),
+        short_hash: parts[0].chars().take(7).collect(),
+        author: parts[1].to_string(),
+        date: parts[2].to_string(),
+        message,
+        files_changed,
+    })
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,12 @@
+//! Small shared utilities
+
+/// Truncate a string to max length (Unicode-safe)
+pub fn truncate(s: &str, max_len: usize) -> String {
+    if s.chars().count() <= max_len {
+        s.to_string()
+    } else {
+        let char_len = max_len.saturating_sub(3);
+        let truncated: String = s.chars().take(char_len).collect();
+        format!("{}...", truncated)
+    }
+}


### PR DESCRIPTION
## Summary

Part 5 of the series (stacked on #204). Pure refactor — **zero behavior change**, verified by building the pre-refactor binary and diffing outputs (`opencode install`/`update` file trees and stdout, `nodes`, `show`, `graph`, `dot`, `writeup`, `pulse`, `audit`) against the new binary: byte-identical.

- **`opencode.rs` install/update dedup**: both functions carried byte-for-byte copies of the command/skill/plugin tables and file-writing logic (~200 lines). Now shared `OPENCODE_COMMANDS`/`OPENCODE_SKILLS`/`OPENCODE_PLUGINS` consts + one writer function; `install` keeps its config-gated plugin selection. Previously, adding a command meant editing two lists in lockstep — a parity test now locks install/update in sync.
- **`DecisionNode` metadata accessors**: the `serde_json::from_str(metadata_json)…get("branch")` idiom was reimplemented ~20 times with subtle variations across seven files. New `metadata()/branch()/confidence()/commit()/prompt()` methods; call sites migrated. The few sites whose semantics genuinely differ (unclamped confidence in DOT export and MCP summaries, signed confidence for color thresholds) deliberately kept their exact behavior.
- **Shared `util::truncate`**: `main.rs` and `export.rs` had identical Unicode-safe copies; now one canonical helper.
- **`emit_sync_events()`**: five copy-pasted ~30-line "check sync dir → build EventLog → append → warn" blocks in `main.rs` collapsed into one helper (exact warning format preserved).
- **DB consolidation**: `get_graph()` delegates to `get_graph_with_config(None)`; the two change-id migration paths share extracted column-check/backfill helpers while keeping their distinct index-creation/early-return semantics.
- Also fixed one more panic-prone byte slice on a user-supplied commit value in the writeup badge (same class as #203's UTF-8 fixes).

Net: **11 files, +574 / −610.**

## Test plan
- 11 new tests: install/update parity, accessor edge cases (clamping, malformed JSON, missing fields)
- `cargo test` — 307 pass · clippy `-D warnings` clean · fmt clean
- Old-vs-new binary output diffing as described above

🤖 Generated with [Claude Code](https://claude.com/claude-code)